### PR TITLE
Mime types and simulataneous processes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ADD client/ /client/
 RUN yarn build
 
 COPY nginx.conf /etc/nginx/
-RUN service nginx start
 
+COPY docker-init.sh .
 EXPOSE 80
-ENTRYPOINT ["yarn", "mock-server"]
+ENTRYPOINT ["./docker-init.sh"]

--- a/docker-init.sh
+++ b/docker-init.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+echo "Starting mock API server and nginx ..."
+
+cd /client
+yarn mock-server &
+
+service nginx start

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,3 +1,5 @@
+daemon off;
+
 worker_processes 1;
 
 events { worker_connections 1024; }
@@ -14,6 +16,9 @@ http {
     server {
         listen 80;
         root /client/build;
+
+        # Set content headers based on file extensions
+        include mime.types;
 
         # Turn on compression for certain file types
         gzip on;


### PR DESCRIPTION
Two small fixes:
1. start both nginx and the mock-server in the entrypoint (via docker-init.sh)
2. serve correct mime-types from nginx
