### PR TITLE
[ch194] Dummy data for database

### DIFF
--- a/api/database.py
+++ b/api/database.py
@@ -1,6 +1,7 @@
 import databases
 import uuid
 
+import click
 from sqlalchemy import create_engine, Table, Boolean, Column, Integer, Float, String, DateTime, ForeignKey
 from sqlalchemy.orm import relationship, sessionmaker
 from sqlalchemy.ext.declarative import declarative_base
@@ -56,7 +57,7 @@ class Organization(Base):
 
     id = Column(GUID, primary_key=True)
     name = Column(String(255), nullable=False)
-    teams = relationship('Team')
+    teams = relationship('Team', back_populates='organization')
 
     created = Column(TIMESTAMP,
                      server_default=func.now(), nullable=False)
@@ -193,6 +194,7 @@ class Record(Base):
     __tablename__ = 'record'
 
     id = Column(GUID, primary_key=True)
+    dataset = relationship('Dataset', back_populates='records')
     dataset_id = Column(GUID, ForeignKey(
         'dataset.id'), nullable=False, index=True)
     publication_date = Column(DateTime)
@@ -206,12 +208,52 @@ class Record(Base):
                      server_default=func.now(), onupdate=func.now())
     deleted = Column(TIMESTAMP)
 
-if __name__ == '__main__':
+
+@click.command()
+@click.option("--tables/--no-tables", default=True)
+@click.option("--dummy-data/--no-dummy-data", default=False)
+def run(tables: bool, dummy_data: bool):
     engine = create_engine('postgresql+psycopg2://' + DATABASE_URL)
-
-    Base.metadata.create_all(engine)
-
     session = SessionLocal()
-    session.add(Role(
-        name="admin", description="User is an admin and has administrative privileges"))
-    session.commit()
+
+    if tables:
+        Base.metadata.create_all(engine)
+
+        session.add(Role(
+            name="admin",
+            description="User is an admin and has administrative privileges"))
+        session.commit()
+
+    if dummy_data:
+        org = Organization(name='BBC')
+
+        team = Team(name='News Team')
+        org.teams.append(team)
+
+        user = User(id='cd7e6d44-4b4d-4d7a-8a67-31efffe53e77',
+                email='tester@notrealemail.info',
+                hashed_password='c053ecf9ed41df0311b9df13cc6c3b6078d2d3c2',
+                first_name='Cat', last_name='Berry')
+        team.users.append(user)
+
+        program = Program(name='BBC News',
+                description='All BBC news programming')
+        team.programs.append(program)
+
+        ds1 = Dataset(name='Breakfast Hour',
+                description='breakfast hour programming')
+        ds2 = Dataset(name='12PM - 4PM', description='afternoon programming')
+        program.datasets.append(ds1)
+
+        tag = Tag(name='news', description='tag for all news programming',
+                tag_type='news')
+        tag.programs.append(program)
+        tag.datasets.append(ds1)
+        tag.datasets.append(ds2)
+
+        session.add(org)
+        session.commit()
+
+
+if __name__ == '__main__':
+    run()

--- a/api/database.py
+++ b/api/database.py
@@ -1,3 +1,11 @@
+"""Define and manage database schema.
+
+Run this as a script to create the database tables:
+    python database.py --tables
+
+Can also add dummy data for development with:
+    python database.py --tables --dummy-data
+"""
 import databases
 import uuid
 
@@ -55,9 +63,9 @@ program_tags = Table('program_tag', Base.metadata,
 class Organization(Base):
     __tablename__ = 'organization'
 
-    id = Column(GUID, primary_key=True)
+    id = Column(GUID, primary_key=True, default=uuid.uuid4)
     name = Column(String(255), nullable=False)
-    teams = relationship('Team', back_populates='organization')
+    teams = relationship('Team')
 
     created = Column(TIMESTAMP,
                      server_default=func.now(), nullable=False)
@@ -69,7 +77,7 @@ class Organization(Base):
 class Team(Base):
     __tablename__ = 'team'
 
-    id = Column(GUID, primary_key=True)
+    id = Column(GUID, primary_key=True, default=uuid.uuid4)
     name = Column(String(255), nullable=False)
     users = relationship('User', secondary=user_teams, backref='Team')
     programs = relationship('Program')
@@ -105,7 +113,7 @@ class User(Base, SQLAlchemyBaseUserTable):
 class Role(Base):
     __tablename__ = 'role'
 
-    id = Column(GUID, primary_key=True)
+    id = Column(GUID, primary_key=True, default=uuid.uuid4)
     name = Column(String(255), nullable=False)
     description = Column(String(255), nullable=False)
 
@@ -118,7 +126,7 @@ class Role(Base):
 class Program(Base):
     __tablename__ = 'program'
 
-    id = Column(GUID, primary_key=True)
+    id = Column(GUID, primary_key=True, default=uuid.uuid4)
     name = Column(String(255), nullable=False)
     description = Column(String(255), nullable=False)
     team_id = Column(GUID, ForeignKey('team.id'), index=True)
@@ -137,7 +145,7 @@ class Program(Base):
 class Tag(Base):
     __tablename__ = 'tag'
 
-    id = Column(GUID, primary_key=True)
+    id = Column(GUID, primary_key=True, default=uuid.uuid4)
     name = Column(String(255), nullable=False)
     description = Column(String(255), nullable=False)
     tag_type = Column(String(255), nullable=False)
@@ -156,7 +164,7 @@ class Tag(Base):
 class Target(Base):
     __tablename__ = 'target'
 
-    id = Column(GUID, primary_key=True)
+    id = Column(GUID, primary_key=True, default=uuid.uuid4)
     program_id = Column(GUID, ForeignKey('program.id'), index=True)
     category = Column(String(255), nullable=False)
     category_value = Column(String(255), nullable=False)
@@ -193,7 +201,7 @@ class Dataset(Base):
 class Record(Base):
     __tablename__ = 'record'
 
-    id = Column(GUID, primary_key=True)
+    id = Column(GUID, primary_key=True, default=uuid.uuid4)
     dataset = relationship('Dataset', back_populates='records')
     dataset_id = Column(GUID, ForeignKey(
         'dataset.id'), nullable=False, index=True)
@@ -213,6 +221,7 @@ class Record(Base):
 @click.option("--tables/--no-tables", default=True)
 @click.option("--dummy-data/--no-dummy-data", default=False)
 def run(tables: bool, dummy_data: bool):
+    """Create tables and dummy data (if requested)."""
     engine = create_engine('postgresql+psycopg2://' + DATABASE_URL)
     session = SessionLocal()
 
@@ -220,6 +229,7 @@ def run(tables: bool, dummy_data: bool):
         Base.metadata.create_all(engine)
 
         session.add(Role(
+            id="be5f8cac-ac65-4f75-8052-8d1b5d40dffe",
             name="admin",
             description="User is an admin and has administrative privileges"))
         session.commit()

--- a/api/database.py
+++ b/api/database.py
@@ -226,6 +226,7 @@ def run(tables: bool, dummy_data: bool):
     session = SessionLocal()
 
     if tables:
+        print("🍽  Creating tables ...")
         Base.metadata.create_all(engine)
 
         session.add(Role(
@@ -235,6 +236,7 @@ def run(tables: bool, dummy_data: bool):
         session.commit()
 
     if dummy_data:
+        print("👩🏽‍💻 Adding dummy data ...")
         org = Organization(name='BBC')
 
         team = Team(name='News Team')
@@ -263,6 +265,8 @@ def run(tables: bool, dummy_data: bool):
 
         session.add(org)
         session.commit()
+
+    print("✅ done!")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Makes some mock data based on https://github.com/stanford-policylab/bbc-50-50/pull/25/commits/b6e5022e7e7e11b2b8588663e48ce24b680aecb7

Added some defaults for the columns as well so they're easier to work with.

Create the mock data with:
```
python database.py --no-tables --dummy-data
```
(you can omit the `--no-tables` flag to simultaneously create the tables)