### PR TITLE
[ch169] "Publication date" defaults to today for new data

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,7 @@
     "i18next": "^19.9.1",
     "i18next-browser-languagedetector": "^6.0.1",
     "i18next-http-backend": "^1.1.1",
+    "mockdate": "^3.0.5",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-i18next": "^11.8.8",

--- a/client/src/__tests__/DataEntry.test.tsx
+++ b/client/src/__tests__/DataEntry.test.tsx
@@ -10,6 +10,7 @@ import { autoMockedClient } from "../__mocks__/AutoMockProvider";
 import { GraphQLError } from "graphql";
 import { ApolloProvider } from "@apollo/client";
 import { DataEntry } from "../components/DataEntry/DataEntry";
+import MockDate from "mockdate";
 
 const history = createMemoryHistory();
 
@@ -82,10 +83,14 @@ test("should load and return error if dataset query fails", async () => {
   ).toBeInTheDocument();
 });
 
-test("should render add entry form when a record id does not exist in route params", async () => {
+test("should render add entry form with today's date when a record id does not exist in route params", async () => {
   (useParams as jest.Mock).mockReturnValue({
     datasetId: "5a8ee1d5-2b5a-49db-b466-68fe50a27cdb",
   });
+
+  // Sets a fixed date of Sunday, 14 June 2015 22:12:05.275
+  // (2015-06-14)
+  MockDate.set(1434319925275);
 
   const client = autoMockedClient();
 
@@ -106,7 +111,11 @@ test("should render add entry form when a record id does not exist in route para
   );
 
   expect(screen.getByRole("form"));
-  screen.getByLabelText("publicationDate");
+  expect(
+    screen.getByLabelText("publicationDate", {
+      selector: "input",
+    })
+  ).toHaveValue("2015-06-14");
 
   expect(screen.getAllByRole("textbox")).toHaveLength(6);
 
@@ -121,9 +130,12 @@ test("should render add entry form when a record id does not exist in route para
   screen.getByRole("button", {
     name: /Cancel and Return To Dashboard/i,
   });
+
+  // Reset fixed date
+  MockDate.reset();
 });
 
-test("should render edit entry form when a record id exists in route params", async () => {
+test("should render edit entry form with record's date when a record id exists in route params", async () => {
   (useParams as jest.Mock).mockReturnValue({
     datasetId: "5a8ee1d5-2b5a-49db-b466-68fe50a27cdb",
     recordId: "05caae8d-bb1a-416e-9dda-bb251fe474ff",
@@ -148,7 +160,12 @@ test("should render edit entry form when a record id exists in route params", as
   );
 
   expect(screen.getByRole("form"));
-  expect(screen.getByLabelText("publicationDate"));
+  expect(
+    screen.getByLabelText("publicationDate", {
+      selector: "input",
+    })
+  ).toHaveValue("2020-12-20");
+
   expect(screen.getAllByRole("textbox")).toHaveLength(6);
 
   screen.getByRole("button", { name: /Update Record/i });

--- a/client/src/components/DataEntry/DataEntryAggregateDataEntryForm.tsx
+++ b/client/src/components/DataEntry/DataEntryAggregateDataEntryForm.tsx
@@ -85,8 +85,7 @@ const DataEntryAggregateDataEntryForm = (props: FormProps): JSX.Element => {
   const [values, setValues] = useState<Entry[]>(entries);
 
   const [formPublicationDate, setFormPublicationDate] = useState<string>(
-    dayjs(props.existingRecord?.record?.publicationDate).format("YYYY-MM-DD") ||
-      dayjs().format("YYYY-MM-DD")
+    dayjs(props.existingRecord?.record?.publicationDate).format("YYYY-MM-DD")
   );
 
   const [error, setError] = useState<Error>();

--- a/client/src/components/DataEntry/DataEntryAggregateDataEntryForm.tsx
+++ b/client/src/components/DataEntry/DataEntryAggregateDataEntryForm.tsx
@@ -85,7 +85,7 @@ const DataEntryAggregateDataEntryForm = (props: FormProps): JSX.Element => {
   const [values, setValues] = useState<Entry[]>(entries);
 
   const [formPublicationDate, setFormPublicationDate] = useState<string>(
-    props.existingRecord?.record?.publicationDate ||
+    dayjs(props.existingRecord?.record?.publicationDate).format("YYYY-MM-DD") ||
       dayjs().format("YYYY-MM-DD")
   );
 

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -10191,6 +10191,11 @@ mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.5, mkdirp@~0.5.1:
   dependencies:
     minimist "^1.2.5"
 
+mockdate@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-3.0.5.tgz#789be686deb3149e7df2b663d2bc4392bc3284fb"
+  integrity sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==
+
 moment@2.29.1, moment@^2.15.2, moment@^2.22.1, moment@^2.24.0, moment@^2.25.3:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"


### PR DESCRIPTION
Story details: https://app.clubhouse.io/stanford-computational-policy-lab/story/169

Today's date was already default for adding new data.

### Changes:
- update data entry tests to expect the form date to be the correct format for add and edit entries
- add a mock date library for mocking dates in tests 
- parse datetime from record to date string (was broken before)