### PR TITLE
Check for admin role

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,7 +1,9 @@
 ariadne==0.13.0
 asyncpg==0.22.0
 bcrypt==3.2.0
+certifi==2021.5.30
 cffi==1.14.5
+chardet==4.0.0
 click==7.1.2
 databases==0.4.3
 Deprecated==1.2.12
@@ -13,7 +15,7 @@ fastapi-users==5.1.2
 graphql-core==3.1.5
 gunicorn==20.0.4
 h11==0.12.0
-idna==3.1
+idna==2.10
 install==1.3.4
 itsdangerous==1.1.0
 Jinja2==2.11.2
@@ -27,10 +29,12 @@ PyJWT==2.0.1
 python-dateutil==2.8.1
 python-dotenv==0.15.0
 python-multipart==0.0.5
+requests==2.25.1
 six==1.15.0
 SQLAlchemy==1.3.23
 starlette==0.13.6
 typing-extensions==3.10.0.0
+urllib3==1.26.5
 uvicorn==0.13.4
 Werkzeug==1.0.1
 wrapt==1.12.1

--- a/client/src/__mocks__/auth.ts
+++ b/client/src/__mocks__/auth.ts
@@ -92,10 +92,9 @@ export const mockUserLogIn = (email: string, password: string) => {
           expect(props?.credentials).toEqual("same-origin");
 
           // Check username password; return unauthorized if they don't match
-          const form = props?.body as FormData;
           if (
-            form.get("username") !== email ||
-            form.get("password") !== password
+            (props?.body as FormData).get("username") !== email ||
+            (props?.body as FormData).get("password") !== password
           ) {
             return new Response(JSON.stringify({ detail: "Unauthorized" }), {
               headers: new Headers({ "Content-Type": "application/json" }),

--- a/client/src/__mocks__/auth.ts
+++ b/client/src/__mocks__/auth.ts
@@ -16,7 +16,9 @@ const defaultUser: UserProfile = {
   last_name: "Pomegranate",
   email: "penelope@pomegran.ate",
   is_active: true,
+  is_verified: true,
   id: "cb1aa2f7-2b27-4649-ba0d-f5c1e60fbb92",
+  roles: [],
 };
 
 /**

--- a/client/src/__tests__/auth.test.tsx
+++ b/client/src/__tests__/auth.test.tsx
@@ -1,0 +1,39 @@
+import { mockUserLoggedIn, mockUserLogIn } from "../__mocks__/auth";
+
+it("marks user as admin correctly", async () => {
+  const { auth } = mockUserLoggedIn({ roles: ["admin"] });
+  await auth.init();
+  expect(auth.isAdmin()).toBe(true);
+});
+
+it("marks user as non-admin correctly", async () => {
+  const { auth } = mockUserLoggedIn({ roles: [] });
+  expect(auth.isAdmin()).toBe(false);
+  await auth.init();
+  expect(auth.isAdmin()).toBe(false);
+});
+
+it("logs a user in and out correctly", async () => {
+  const user = "tester@notrealemail.info";
+  const password = "password";
+  const { auth } = mockUserLogIn(user, password);
+  await auth.init();
+
+  expect(await auth.login(user, password)).toBeNull();
+  expect(auth.isLoggedIn()).toBe(true);
+  expect(auth.getFullName()).toEqual("Penelope Pomegranate");
+
+  expect(await auth.logout()).toBeNull();
+  expect(auth.isLoggedIn()).toBe(false);
+});
+
+it("reports an error if user is not authed", async () => {
+  const user = "tester@notrealemail.info";
+  const password = "password";
+  const { auth } = mockUserLogIn(user, password);
+  await auth.init();
+
+  expect(await auth.login("wrong", "password")).toEqual("Unauthorized");
+  expect(auth.isLoggedIn()).toBe(false);
+  expect(auth.getFullName()).toEqual("");
+});

--- a/client/src/services/auth.ts
+++ b/client/src/services/auth.ts
@@ -64,7 +64,7 @@ export class Auth {
    * Test whether user has admin permissions.
    */
   public isAdmin() {
-    return !!this.currentUser && this.currentUser.roles.contains("admin");
+    return !!this.currentUser && this.currentUser.roles.includes("admin");
   }
 
   /**

--- a/client/src/services/auth.ts
+++ b/client/src/services/auth.ts
@@ -177,6 +177,7 @@ export class Auth {
       return "An error occurred trying to sign out.";
     }
 
+    this.currentUser = null;
     return null;
   }
 

--- a/client/src/services/auth.ts
+++ b/client/src/services/auth.ts
@@ -5,8 +5,10 @@ export type UserProfile = Readonly<{
   id: string;
   email: string;
   is_active: boolean;
+  is_verified: boolean;
   first_name: string;
   last_name: string;
+  roles: string[];
 }>;
 
 /**
@@ -56,6 +58,13 @@ export class Auth {
    */
   public isLoggedIn() {
     return !!this.currentUser;
+  }
+
+  /**
+   * Test whether user has admin permissions.
+   */
+  public isAdmin() {
+    return !!this.currentUser && this.currentUser.roles.contains("admin");
   }
 
   /**


### PR DESCRIPTION
The built-in fastapi-users `/users` router won't return our custom roles. Didn't see a super obvious way to make fastapi-users work better with the sqlalchemy ORM, so I just added a simple drop-in replacement for the `/users/me` route that returns the `roles`.

This also adds a test on the frontend `Auth#isAdmin` to check whether the user should see the admin portal.