### PR TITLE
User management API routes

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -138,7 +138,7 @@ async def add_user(request: Request, call_next):
     if settings.debug and "X-User" in request.headers:
         user = User.get_by_email(session=dbsession, email=request.headers['X-User'])
     else:
-        # TODO(jnu): fastapi_users.current_user is meant to be called with
+        # NOTE(jnu): fastapi_users.current_user is meant to be called with
         # FastAPI's `Depends`. We have to hook into their "blood magic" here
         # to call it outside of Depends.
         user_db = await fastapi_users.current_user(active=True, optional=True)(cookie=request.cookies.get('rtauth'))

--- a/api/app.py
+++ b/api/app.py
@@ -3,9 +3,7 @@ import databases
 import sqlalchemy
 import datetime
 
-from fastapi import FastAPI, Request, Depends
-# from fastapi_sqlalchemy import DBSessionMiddleware  # middleware helper
-# from fastapi_sqlalchemy import db  # an object to provide global access to a database session
+from fastapi import FastAPI, Request, Depends, HTTPException
 from fastapi_users.authentication import CookieAuthentication
 from fastapi_users import FastAPIUsers
 from sqlalchemy.ext.declarative import DeclarativeMeta, declarative_base
@@ -42,24 +40,35 @@ cookie_authentication = CookieAuthentication(
 fastapi_users = FastAPIUsers(
     user.user_db,
     [cookie_authentication],
-    user.User,
-    user.UserCreate,
-    user.UserUpdate,
-    user.UserDB,
+    user.UserModel,
+    user.UserCreateModel,
+    user.UserUpdateModel,
+    user.UserDBModel,
 )
 
 
 # Add login functions 
-def on_after_register(user: user.UserDB, request: Request):
+def on_after_register(user: user.UserDBModel, request: Request):
     print(f"User {user.id} has registered.")
 
 
-def on_after_forgot_password(user: user.UserDB, token: str, request: Request):
+def on_after_forgot_password(user: user.UserDBModel, token: str, request: Request):
     print(f"User {user.id} has forgot their password. Reset token: {token}")
 
 
-def after_verification_request(user: user.UserDB, token: str, request: Request):
+def after_verification_request(user: user.UserDBModel, token: str, request: Request):
     print(f"Verification requested for user {user.id}. Verification token: {token}")
+
+
+def admin_user(request: Request):
+    """Dependency to verify that a user is an admin."""
+    user = request.scope.get('dbuser')
+    if not user:
+        raise HTTPException(status_code=401, detail="You are not authenticated")
+    if not any(r.name == 'admin' for r in user.roles):
+        raise HTTPException(status_code=403, detail="You do not have permission for this action")
+    return user
+    
 
 
 # Add restful routers for user management
@@ -67,7 +76,10 @@ app.include_router(
     fastapi_users.get_auth_router(cookie_authentication), prefix="/auth/cookie", tags=["auth"]
 )
 app.include_router(
-    fastapi_users.get_register_router(on_after_register), prefix="/auth", tags=["auth"]
+    fastapi_users.get_register_router(on_after_register),
+    prefix="/auth",
+    dependencies=[Depends(admin_user)],
+    tags=["auth"],
 )
 app.include_router(
     fastapi_users.get_reset_password_router(
@@ -84,25 +96,13 @@ app.include_router(
     tags=["auth"],
 )
 
-# Dependency to get the current authed user from the cookie.
-get_current_user_dep = fastapi_users.current_user(active=True)
+app.include_router(
+    fastapi_users.get_users_router(),
+     prefix="/users",
+     tags=["users"],
+)
 
-# Use a custom implementation of the /users/me instead of fastapi-users's.
-# Their permissions are too simple for us; we want to return a list of roles
-# for the user. Behavior around 200 and 401 responses is otherwise the same.
-@app.get("/users/me")
-def get_current_user(request: Request, user: user.User = Depends(get_current_user_dep)):
-    session = request.scope["dbsession"]
-    dbuser = session.query(User).get(user.id)
-    return {
-            "id": dbuser.id,
-            "roles": [r.name for r in dbuser.roles],
-            "first_name": dbuser.first_name,
-            "last_name": dbuser.last_name,
-            "email": dbuser.email,
-            "is_active": dbuser.is_active,
-            "is_verified": dbuser.is_verified,
-            }
+
 
 
 # General Graphql Field Resolvers
@@ -129,6 +129,26 @@ schema = make_executable_schema(
     directives={"needsPermission": directives.NeedsPermissionDirective}
 )
 
+
+@app.middleware("http")
+async def add_user(request: Request, call_next):
+    dbsession = request.scope["dbsession"]
+
+    # allow for manual specification of user in request header by email
+    if settings.debug and "X-User" in request.headers:
+        user = User.get_by_email(session=dbsession, email=request.headers['X-User'])
+    else:
+        # TODO(jnu): fastapi_users.current_user is meant to be called with
+        # FastAPI's `Depends`. We have to hook into their "blood magic" here
+        # to call it outside of Depends.
+        user_db = await fastapi_users.current_user(active=True, optional=True)(cookie=request.cookies.get('rtauth'))
+        # The permissions checks use the ORM object, not the Pydantic model. 
+        user = dbsession.query(User).get(user_db.id) if user_db else None
+
+    request.scope["dbuser"] = user
+    return await call_next(request)
+
+
 @app.middleware("http")
 async def add_db_session(request: Request, call_next):
     session = app.extra['get_db_session']()
@@ -140,24 +160,14 @@ async def add_db_session(request: Request, call_next):
 
     return response
 
+
 async def get_context(request: Request):
     dbsession = request.scope['dbsession']
-    
-    # allow for manual specification of user in request header by email
-    if settings.debug and "X-User" in request.headers:
-        user = User.get_by_email(session=dbsession, email=request.headers['X-User'])
-    else:
-        # TODO(jnu): fastapi_users.current_user is meant to be called with
-        # FastAPI's `Depends`. We have to hook into their "blood magic" here
-        # to call it outside of Depends.
-        user_db = await fastapi_users.current_user(active=True, optional=True)(cookie=request.cookies.get('rtauth'))
-        # TODO(jnu): The users.UserDB and database.User model should be unified.
-        user = dbsession.query(User).get(user_db.id) if user_db else None
-                
+    dbuser = request.scope['dbuser']
     return {
             "dbsession": dbsession,
             "request": request,
-            "current_user": user
+            "current_user": dbuser,
             }
 
 # Mount ariadne to fastapi

--- a/api/database.py
+++ b/api/database.py
@@ -141,6 +141,19 @@ class User(Base, SQLAlchemyBaseUserTable):
                 User.deleted == None,
                 ).first()
 
+    @classmethod
+    def delete(cls, session: SessionLocal, id) -> None:
+        """Delete a user by their ID.
+
+        This is a soft delete; the record will stay in the database.
+
+        :param session: Database session
+        :param id: UUID of user
+        """
+        return session.query(User).filter(User.id == id).update({
+            User.delete: func.now(),
+            }, synchronize_session='fetch')
+
 
 class Role(Base):
     __tablename__ = 'role'

--- a/api/database.py
+++ b/api/database.py
@@ -30,6 +30,7 @@ database = databases.Database("postgres://" + DATABASE_URL)
 engine = create_engine('postgresql+psycopg2://' + DATABASE_URL, pool_pre_ping=True)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
+
 Base = declarative_base()
 
 # Handling Many-to-Many Relationships

--- a/api/user.py
+++ b/api/user.py
@@ -1,30 +1,99 @@
+from pydantic import BaseModel, UUID4, EmailStr
 from fastapi_users import models
-from fastapi_users.db import (SQLAlchemyUserDatabase)
-from typing import Optional
+from fastapi_users.db.base import BaseUserDatabase
+from fastapi_users.db.sqlalchemy import GUID
+from typing import Optional, List
 import database
 
 
-class User(models.BaseUser):
+
+class UserRole(BaseModel):
+    name: str
+    description: str
+
+    class Config:
+        orm_mode = True
+
+
+class UserModel(models.BaseUser):
     first_name: str
     last_name: str
+    roles: List[UserRole]
 
 
-class UserCreate(models.BaseUserCreate):
+class UserCreateModel(models.BaseUserCreate):
     first_name: str
     last_name: str
+    roles: Optional[List[str]]
 
 
-class UserUpdate(User, models.BaseUserUpdate):
+class UserUpdateModel(UserModel, models.BaseUserUpdate):
     first_name: Optional[str]
     last_name: Optional[str]
+    roles: Optional[List[str]]
 
 
-class UserDB(User, models.BaseUserDB):
-    # NOTE(jnu): the database.User model is much more useful than this one.
-    # We should figure out how to unify them.
+class UserDBModel(UserModel, models.BaseUserDB):
     first_name: str
     last_name: str
 
 
-user_db = SQLAlchemyUserDatabase(
-    UserDB, database.database, database.User.__table__)
+class SQLAlchemyORMUserDatabase(BaseUserDatabase):
+    """FastAPI-Users database integration for SQLAlchemy ORM.
+
+    Based on SQLAlchemyUserDatabase:
+    https://github.com/frankie567/fastapi-users/blob/c83bdeb0e0004692f398ad89a4fdeaaa125900d5/fastapi_users/db/sqlalchemy.py#L92
+    """
+
+    def __init__(self, session_factory):
+        super().__init__(UserDBModel)
+        self.session_factory = session_factory
+
+    async def get(self, id: UUID4) -> UserDBModel:
+        # TODO! Use an async session
+        session = self.session_factory()
+        dbuser = session.query(database.User).get(id)
+        user = UserDBModel.from_orm(dbuser) if dbuser else None
+        session.close()
+        return user
+
+    async def get_by_email(self, email: EmailStr) -> UserDBModel:
+        # TODO! Use an async session
+        session = self.session_factory()
+        dbuser = database.User.get_by_email(session, email)
+        user = UserDBModel.from_orm(dbuser) if dbuser else None
+        session.close()
+        return user
+
+    async def create(self, user: UserCreateModel) -> UserDBModel:
+        # TODO! Use an async session
+        session = self.session_factory()
+        d = user.dict()
+        d['roles'] = [database.Role.get_by_name(r) for r in user.roles]
+        dbuser = database.User(**d)
+        session.add(dbuser)
+        session.commit()
+        user = UserDBModel.from_orm(dbuser)
+        session.close()
+        return user
+    
+    async def update(self, user: UserUpdateModel) -> UserDBModel:
+        # TODO! Use an async session
+        session = self.session_factory()
+        d = user.dict()
+        d['roles'] = [database.Role.get_by_name(r) for r in user.roles]
+        dbuser = database.User(**d)
+        session.merge(dbuser)
+        session.commit()
+        user = UserDBModel.from_orm(dbuser)
+        session.close()
+        return user
+
+    async def delete(self, user: UserModel) -> None:
+        session = self.session_factory()
+        database.User.delete(session, user.id)
+        session.commit()
+        session.close()
+
+
+user_db = SQLAlchemyORMUserDatabase(database.SessionLocal)

--- a/client/src/__tests__/App.snapshot.test.tsx
+++ b/client/src/__tests__/App.snapshot.test.tsx
@@ -43,7 +43,9 @@ test("renders ProtectedAppContainer correctly", async () => {
 });
 
 it("renders admin stuff when authed as admin", async () => {
-  const { auth, mock } = mockUserLoggedIn({ roles: ["admin"] });
+  const { auth, mock } = mockUserLoggedIn({
+    roles: [{ name: "admin", description: "" }],
+  });
   await auth.init();
 
   const tree = shallow(<App />, {
@@ -55,7 +57,9 @@ it("renders admin stuff when authed as admin", async () => {
 });
 
 it("renders custom sidebar for admin", async () => {
-  const { auth, mock } = mockUserLoggedIn({ roles: ["admin"] });
+  const { auth, mock } = mockUserLoggedIn({
+    roles: [{ name: "admin", description: "" }],
+  });
   await auth.init();
 
   const tree = mount(

--- a/client/src/__tests__/auth.test.tsx
+++ b/client/src/__tests__/auth.test.tsx
@@ -1,7 +1,9 @@
 import { mockUserLoggedIn, mockUserLogIn } from "../__mocks__/auth";
 
 it("marks user as admin correctly", async () => {
-  const { auth } = mockUserLoggedIn({ roles: ["admin"] });
+  const { auth } = mockUserLoggedIn({
+    roles: [{ name: "admin", description: "" }],
+  });
   await auth.init();
   expect(auth.isAdmin()).toBe(true);
 });

--- a/client/src/services/auth.ts
+++ b/client/src/services/auth.ts
@@ -1,4 +1,12 @@
 /**
+ * Description of a role assigned to a user.
+ */
+export type UserRole = Readonly<{
+  name: string;
+  description: string;
+}>;
+
+/**
  * Information about the currently authenticated user.
  */
 export type UserProfile = Readonly<{
@@ -8,7 +16,7 @@ export type UserProfile = Readonly<{
   is_verified: boolean;
   first_name: string;
   last_name: string;
-  roles: string[];
+  roles: UserRole[];
 }>;
 
 /**
@@ -64,7 +72,10 @@ export class Auth {
    * Test whether user has admin permissions.
    */
   public isAdmin() {
-    return !!this.currentUser && this.currentUser.roles.includes("admin");
+    return (
+      !!this.currentUser &&
+      this.currentUser.roles.some((r) => r.name === "admin")
+    );
   }
 
   /**


### PR DESCRIPTION
Revises the fastapi-users sqlalchemy integration to be compatible with ORM.

still left to do:
 - [x] restrict permissions on register route
 - [x] tests