### PR TITLE
Add retype password input, clean up unused variables

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -23,9 +23,11 @@ module.exports = {
   ],
   plugins: ["react-hooks"],
   rules: {
+    "react/jsx-uses-react": "off",
+    "react/react-in-jsx-scope": "off",
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
     "no-unused-vars": "off",
-    "@typescript-eslint/no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": "error",
   },
 };

--- a/client/package.json
+++ b/client/package.json
@@ -147,6 +147,7 @@
     "jest-axe": "^4.1.0",
     "jest-transform-stub": "^2.0.0",
     "prettier": "^2.3.0",
+    "prettier-plugin-organize-imports": "^2.2.0",
     "pretty-quick": "^3.1.0",
     "react-axe": "^3.5.4",
     "react-test-renderer": "^17.0.1",

--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -35,6 +35,8 @@
       "subtitle": "Enter a new password and press \"save\"",
       "submit": "Save",
       "newPasswordLabel": "New password",
+      "retypePasswordLabel": "Re-type password",
+      "passwordsDoNotMatch": "These two passwords do not match",
       "success": "You have successfully reset your password!",
       "error": "Failed to reset password",
       "action": "Request new link",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -17,7 +17,6 @@ const { Footer, Content } = Layout;
  */
 export function ProtectedAppContainer({
   children,
-  crumbs,
 }: {
   children?: React.ReactNode;
   crumbs?: boolean;

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,14 +1,13 @@
+import { Layout } from "antd";
 import React, { Suspense } from "react";
 import { BrowserRouter } from "react-router-dom";
-import { Layout } from "antd";
+import "./App.css";
+import { Loading } from "./components/Loading/Loading";
 import AppHeader from "./layout/AppHeader";
 import { AppSidebar } from "./layout/AppSidebar";
-import "./App.css";
 import { Login } from "./pages/Login/Login";
-import { Loading } from "./components/Loading/Loading";
-
-import { normalRoutes, adminRoutes } from "./router/routes";
 import { RenderRoutes } from "./router/Router";
+import { adminRoutes, normalRoutes } from "./router/routes";
 
 const { Footer, Content } = Layout;
 

--- a/client/src/__tests__/AdminEditProgram.test.tsx
+++ b/client/src/__tests__/AdminEditProgram.test.tsx
@@ -1,18 +1,16 @@
-import { render, screen, fireEvent } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import "@testing-library/jest-dom/extend-expect";
-import { Route, MemoryRouter } from "react-router-dom";
 import { MockedProvider } from "@apollo/client/testing";
-
-import { tick } from "./utils";
-
-import { EditProgram } from "../pages/Admin/EditProgram";
-import { ADMIN_GET_ALL_CATEGORIES } from "../graphql/__queries__/AdminGetAllCategories.gql";
-import { ADMIN_GET_ALL_TEAMS } from "../graphql/__queries__/AdminGetAllTeams.gql";
-import { ADMIN_UPDATE_PROGRAM } from "../graphql/__mutations__/AdminUpdateProgram.gql";
+import "@testing-library/jest-dom/extend-expect";
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route } from "react-router-dom";
 import { ADMIN_DELETE_PROGRAM } from "../graphql/__mutations__/AdminDeleteProgram.gql";
 import { ADMIN_RESTORE_PROGRAM } from "../graphql/__mutations__/AdminRestoreProgram.gql";
+import { ADMIN_UPDATE_PROGRAM } from "../graphql/__mutations__/AdminUpdateProgram.gql";
+import { ADMIN_GET_ALL_CATEGORIES } from "../graphql/__queries__/AdminGetAllCategories.gql";
+import { ADMIN_GET_ALL_TEAMS } from "../graphql/__queries__/AdminGetAllTeams.gql";
 import { ADMIN_GET_PROGRAM } from "../graphql/__queries__/AdminGetProgram.gql";
+import { EditProgram } from "../pages/Admin/EditProgram";
+import { tick } from "./utils";
 
 const PROGRAM = {
   data: {

--- a/client/src/__tests__/AdminEditProgram.test.tsx
+++ b/client/src/__tests__/AdminEditProgram.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom/extend-expect";
-import React from "react";
 import { Route, MemoryRouter } from "react-router-dom";
 import { MockedProvider } from "@apollo/client/testing";
 

--- a/client/src/__tests__/AdminEditUser.test.tsx
+++ b/client/src/__tests__/AdminEditUser.test.tsx
@@ -1,15 +1,13 @@
-import { render, screen, fireEvent } from "@testing-library/react";
-import "@testing-library/jest-dom/extend-expect";
-import { MemoryRouter, Route } from "react-router-dom";
 import { MockedProvider } from "@apollo/client/testing";
-
-import { tick, mockUserAccountClient } from "./utils";
+import "@testing-library/jest-dom/extend-expect";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter, Route } from "react-router-dom";
 import { UserAccountManagerProvider } from "../components/UserAccountManagerProvider";
-
-import { EditUser } from "../pages/Admin/EditUser";
-import { ADMIN_GET_USER } from "../graphql/__queries__/AdminGetUser.gql";
 import { ADMIN_GET_ALL_ROLES } from "../graphql/__queries__/AdminGetAllRoles.gql";
 import { ADMIN_GET_ALL_TEAMS } from "../graphql/__queries__/AdminGetAllTeams.gql";
+import { ADMIN_GET_USER } from "../graphql/__queries__/AdminGetUser.gql";
+import { EditUser } from "../pages/Admin/EditUser";
+import { mockUserAccountClient, tick } from "./utils";
 
 const allRolesMock = {
   request: { query: ADMIN_GET_ALL_ROLES },

--- a/client/src/__tests__/AdminEditUser.test.tsx
+++ b/client/src/__tests__/AdminEditUser.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom/extend-expect";
-import React from "react";
 import { MemoryRouter, Route } from "react-router-dom";
 import { MockedProvider } from "@apollo/client/testing";
 

--- a/client/src/__tests__/AdminProgramList.test.tsx
+++ b/client/src/__tests__/AdminProgramList.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom/extend-expect";
-import React from "react";
 import { MemoryRouter } from "react-router-dom";
 import { MockedProvider } from "@apollo/client/testing";
 

--- a/client/src/__tests__/AdminProgramList.test.tsx
+++ b/client/src/__tests__/AdminProgramList.test.tsx
@@ -1,16 +1,14 @@
-import { render, screen, fireEvent } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import "@testing-library/jest-dom/extend-expect";
-import { MemoryRouter } from "react-router-dom";
 import { MockedProvider } from "@apollo/client/testing";
-
-import { tick } from "./utils";
-
-import { ProgramList } from "../pages/Admin/ProgramList";
+import "@testing-library/jest-dom/extend-expect";
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { ADMIN_CREATE_PROGRAM } from "../graphql/__mutations__/AdminCreateProgram.gql";
 import { ADMIN_GET_ALL_PROGRAMS } from "../graphql/__queries__/AdminGetAllPrograms.gql";
 import { ADMIN_GET_ALL_TEAMS } from "../graphql/__queries__/AdminGetAllTeams.gql";
-import { ADMIN_CREATE_PROGRAM } from "../graphql/__mutations__/AdminCreateProgram.gql";
 import { ADMIN_GET_PROGRAM } from "../graphql/__queries__/AdminGetProgram.gql";
+import { ProgramList } from "../pages/Admin/ProgramList";
+import { tick } from "./utils";
 
 const TEAMS = {
   data: {

--- a/client/src/__tests__/AdminUserList.test.tsx
+++ b/client/src/__tests__/AdminUserList.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom/extend-expect";
-import React from "react";
 import { MemoryRouter } from "react-router-dom";
 import { MockedProvider } from "@apollo/client/testing";
 

--- a/client/src/__tests__/AdminUserList.test.tsx
+++ b/client/src/__tests__/AdminUserList.test.tsx
@@ -1,13 +1,11 @@
-import { render, screen, fireEvent } from "@testing-library/react";
-import "@testing-library/jest-dom/extend-expect";
-import { MemoryRouter } from "react-router-dom";
 import { MockedProvider } from "@apollo/client/testing";
-
+import "@testing-library/jest-dom/extend-expect";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { UserAccountManagerProvider } from "../components/UserAccountManagerProvider";
-import { tick, mockUserAccountClient } from "./utils";
-
-import { UserList } from "../pages/Admin/UserList";
 import { GET_USER_LIST } from "../graphql/__queries__/GetUserList.gql";
+import { UserList } from "../pages/Admin/UserList";
+import { mockUserAccountClient, tick } from "./utils";
 
 it("renders list of users for the admin", async () => {
   const apolloMocks = [

--- a/client/src/__tests__/App.snapshot.test.tsx
+++ b/client/src/__tests__/App.snapshot.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { MemoryRouter } from "react-router-dom";
 import { shallow, mount } from "enzyme";
 import toJson from "enzyme-to-json";
@@ -12,7 +11,7 @@ import { Login } from "../pages/Login/Login";
 import { AppSidebar, AppAdminSidebarMenu } from "../layout/AppSidebar";
 
 it("renders App correctly", async () => {
-  const { auth, mock } = mockUserLoggedIn();
+  const { auth } = mockUserLoggedIn();
   await auth.init();
 
   const tree = shallow(<App />, {
@@ -24,7 +23,7 @@ it("renders App correctly", async () => {
 });
 
 it("renders Login when not authed", async () => {
-  const { auth, mock } = mockUserNotLoggedIn();
+  const { auth } = mockUserNotLoggedIn();
   await auth.init();
 
   const tree = mount(<App />, {
@@ -46,7 +45,7 @@ test("renders ProtectedAppContainer correctly", async () => {
 });
 
 it("renders admin stuff when authed as admin", async () => {
-  const { auth, mock } = mockUserLoggedIn({
+  const { auth } = mockUserLoggedIn({
     roles: [{ name: "admin", description: "" }],
   });
   await auth.init();
@@ -60,7 +59,7 @@ it("renders admin stuff when authed as admin", async () => {
 });
 
 it("renders custom sidebar for admin", async () => {
-  const { auth, mock } = mockUserLoggedIn({
+  const { auth } = mockUserLoggedIn({
     roles: [{ name: "admin", description: "" }],
   });
   await auth.init();

--- a/client/src/__tests__/App.snapshot.test.tsx
+++ b/client/src/__tests__/App.snapshot.test.tsx
@@ -1,14 +1,14 @@
-import { MemoryRouter } from "react-router-dom";
-import { shallow, mount } from "enzyme";
+import { mount, shallow } from "enzyme";
 import toJson from "enzyme-to-json";
+import { MemoryRouter } from "react-router-dom";
 import App, { ProtectedAppContainer } from "../App";
+import { AuthProvider } from "../components/AuthProvider";
 import {
   mockUserLoggedIn,
   mockUserNotLoggedIn,
 } from "../graphql/__mocks__/auth";
-import { AuthProvider } from "../components/AuthProvider";
+import { AppAdminSidebarMenu, AppSidebar } from "../layout/AppSidebar";
 import { Login } from "../pages/Login/Login";
-import { AppSidebar, AppAdminSidebarMenu } from "../layout/AppSidebar";
 
 it("renders App correctly", async () => {
   const { auth } = mockUserLoggedIn();

--- a/client/src/__tests__/App.test.tsx
+++ b/client/src/__tests__/App.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { shallow } from "enzyme";
 import App, { ProtectedAppContainer } from "../App";
 import { mockUserLoggedIn } from "../graphql/__mocks__/auth";
@@ -6,7 +5,7 @@ import { AuthProvider } from "../components/AuthProvider";
 
 describe("App Component", () => {
   test("renders correctly", async () => {
-    const { auth, mock } = mockUserLoggedIn();
+    const { auth } = mockUserLoggedIn();
     await auth.init();
 
     const tree = shallow(<App />, {

--- a/client/src/__tests__/App.test.tsx
+++ b/client/src/__tests__/App.test.tsx
@@ -1,7 +1,7 @@
 import { shallow } from "enzyme";
 import App, { ProtectedAppContainer } from "../App";
-import { mockUserLoggedIn } from "../graphql/__mocks__/auth";
 import { AuthProvider } from "../components/AuthProvider";
+import { mockUserLoggedIn } from "../graphql/__mocks__/auth";
 
 describe("App Component", () => {
   test("renders correctly", async () => {

--- a/client/src/__tests__/AppSidebar.test.tsx
+++ b/client/src/__tests__/AppSidebar.test.tsx
@@ -3,7 +3,6 @@ import { AppSidebar } from "../layout/AppSidebar";
 import { MockedProvider } from "@apollo/client/testing";
 import { BrowserRouter } from "react-router-dom";
 import { GET_USER } from "../graphql/__queries__/GetUser.gql";
-import React from "react";
 import i18nextTest from "../services/i18next-test";
 import { AuthProvider } from "../components/AuthProvider";
 import { mockUserLoggedIn } from "../graphql/__mocks__/auth";

--- a/client/src/__tests__/AppSidebar.test.tsx
+++ b/client/src/__tests__/AppSidebar.test.tsx
@@ -1,12 +1,12 @@
 /* eslint-disable react/react-in-jsx-scope */
-import { AppSidebar } from "../layout/AppSidebar";
 import { MockedProvider } from "@apollo/client/testing";
+import { render } from "@testing-library/react";
 import { BrowserRouter } from "react-router-dom";
-import { GET_USER } from "../graphql/__queries__/GetUser.gql";
-import i18nextTest from "../services/i18next-test";
 import { AuthProvider } from "../components/AuthProvider";
 import { mockUserLoggedIn } from "../graphql/__mocks__/auth";
-import { render } from "@testing-library/react";
+import { GET_USER } from "../graphql/__queries__/GetUser.gql";
+import { AppSidebar } from "../layout/AppSidebar";
+import i18nextTest from "../services/i18next-test";
 
 describe("UK English internationalization", () => {
   const mocks = [

--- a/client/src/__tests__/DataEntry.test.tsx
+++ b/client/src/__tests__/DataEntry.test.tsx
@@ -7,7 +7,6 @@ import {
   fireEvent,
 } from "@testing-library/react";
 import "@testing-library/jest-dom/extend-expect";
-import React from "react";
 import { createMemoryHistory } from "history";
 import { Router, useParams } from "react-router-dom";
 import userEvent from "@testing-library/user-event";

--- a/client/src/__tests__/DataEntry.test.tsx
+++ b/client/src/__tests__/DataEntry.test.tsx
@@ -1,20 +1,20 @@
+import { ApolloProvider } from "@apollo/client";
+import "@testing-library/jest-dom/extend-expect";
 import {
   act,
+  cleanup,
+  fireEvent,
   render,
   screen,
   waitFor,
-  cleanup,
-  fireEvent,
 } from "@testing-library/react";
-import "@testing-library/jest-dom/extend-expect";
-import { createMemoryHistory } from "history";
-import { Router, useParams } from "react-router-dom";
 import userEvent from "@testing-library/user-event";
-import { autoMockedClient } from "../graphql/__mocks__/AutoMockProvider";
 import { GraphQLError } from "graphql";
-import { ApolloProvider } from "@apollo/client";
-import { DataEntry } from "../pages/DataEntry/DataEntry";
+import { createMemoryHistory } from "history";
 import MockDate from "mockdate";
+import { Router, useParams } from "react-router-dom";
+import { autoMockedClient } from "../graphql/__mocks__/AutoMockProvider";
+import { DataEntry } from "../pages/DataEntry/DataEntry";
 
 const history = createMemoryHistory();
 

--- a/client/src/__tests__/DatasetDetails.test.tsx
+++ b/client/src/__tests__/DatasetDetails.test.tsx
@@ -1,3 +1,4 @@
+import { ApolloProvider } from "@apollo/client";
 import {
   act,
   fireEvent,
@@ -6,13 +7,12 @@ import {
   waitFor,
   within,
 } from "@testing-library/react";
-import { DatasetDetails } from "../pages/DatasetDetails/DatasetDetails";
+import userEvent from "@testing-library/user-event";
+import { GraphQLError } from "graphql";
 import { createMemoryHistory } from "history";
 import { Router } from "react-router-dom";
-import userEvent from "@testing-library/user-event";
 import { autoMockedClient } from "../graphql/__mocks__/AutoMockProvider";
-import { GraphQLError } from "graphql";
-import { ApolloProvider } from "@apollo/client";
+import { DatasetDetails } from "../pages/DatasetDetails/DatasetDetails";
 
 const history = createMemoryHistory();
 

--- a/client/src/__tests__/DatasetDetails.test.tsx
+++ b/client/src/__tests__/DatasetDetails.test.tsx
@@ -6,7 +6,6 @@ import {
   waitFor,
   within,
 } from "@testing-library/react";
-import React from "react";
 import { DatasetDetails } from "../pages/DatasetDetails/DatasetDetails";
 import { createMemoryHistory } from "history";
 import { Router } from "react-router-dom";

--- a/client/src/__tests__/Home.test.tsx
+++ b/client/src/__tests__/Home.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { act, render, screen, within } from "@testing-library/react";
 import { Home } from "../pages/Home/Home";
 import { createMemoryHistory } from "history";
@@ -25,7 +24,7 @@ async function wait(ms = 0) {
 }
 
 test("should render home page datasets and formatted 'last updated' date", async () => {
-  const { auth, mock } = mockUserLoggedIn();
+  const { auth } = mockUserLoggedIn();
   await auth.init();
 
   const mockDateTime = {
@@ -57,7 +56,7 @@ test("should render home page datasets and formatted 'last updated' date", async
 });
 
 test("should render No Data Available for 'last updated' date when no records exist", async () => {
-  const { auth, mock } = mockUserLoggedIn();
+  const { auth } = mockUserLoggedIn();
   await auth.init();
 
   const mockDateTime = {

--- a/client/src/__tests__/Home.test.tsx
+++ b/client/src/__tests__/Home.test.tsx
@@ -1,12 +1,12 @@
-import { act, render, screen, within } from "@testing-library/react";
-import { Home } from "../pages/Home/Home";
-import { createMemoryHistory } from "history";
 import { ApolloProvider } from "@apollo/client";
-import { Router } from "react-router-dom";
-import { autoMockedClient } from "../graphql/__mocks__/AutoMockProvider";
-import { mockUserLoggedIn } from "../graphql/__mocks__/auth";
-import { AuthProvider } from "../components/AuthProvider";
+import { act, render, screen, within } from "@testing-library/react";
+import { createMemoryHistory } from "history";
 import { axe } from "jest-axe";
+import { Router } from "react-router-dom";
+import { AuthProvider } from "../components/AuthProvider";
+import { mockUserLoggedIn } from "../graphql/__mocks__/auth";
+import { autoMockedClient } from "../graphql/__mocks__/AutoMockProvider";
+import { Home } from "../pages/Home/Home";
 
 const history = createMemoryHistory();
 

--- a/client/src/__tests__/HomeDatasetsListTable.test.tsx
+++ b/client/src/__tests__/HomeDatasetsListTable.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render } from "@testing-library/react";
 import { HomeDatasetsListTable } from "../pages/Home/HomeDatasetsListTable";
 import { axe } from "jest-axe";

--- a/client/src/__tests__/HomeDatasetsListTable.test.tsx
+++ b/client/src/__tests__/HomeDatasetsListTable.test.tsx
@@ -1,6 +1,6 @@
 import { render } from "@testing-library/react";
-import { HomeDatasetsListTable } from "../pages/Home/HomeDatasetsListTable";
 import { axe } from "jest-axe";
+import { HomeDatasetsListTable } from "../pages/Home/HomeDatasetsListTable";
 
 describe("accessibility", () => {
   it("should not have basic accessibility issues", async () => {

--- a/client/src/__tests__/Login.test.tsx
+++ b/client/src/__tests__/Login.test.tsx
@@ -1,13 +1,11 @@
-import { render, screen, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom/extend-expect";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { createMemoryHistory } from "history";
-
-import { UserAccountManagerProvider } from "../components/UserAccountManagerProvider";
-import { tick, mockUserAccountClient } from "./utils";
 import { AuthProvider } from "../components/AuthProvider";
+import { UserAccountManagerProvider } from "../components/UserAccountManagerProvider";
 import { mockUserNotLoggedIn } from "../graphql/__mocks__/auth";
-
 import { Login } from "../pages/Login/Login";
+import { mockUserAccountClient, tick } from "./utils";
 
 it("allows user to reset their password with their email", async () => {
   const { auth } = mockUserNotLoggedIn();

--- a/client/src/__tests__/Login.test.tsx
+++ b/client/src/__tests__/Login.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom/extend-expect";
-import React from "react";
 import { createMemoryHistory } from "history";
 
 import { UserAccountManagerProvider } from "../components/UserAccountManagerProvider";

--- a/client/src/__tests__/ResetAccountPassword.test.tsx
+++ b/client/src/__tests__/ResetAccountPassword.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom/extend-expect";
-import React from "react";
 import { MemoryRouter } from "react-router-dom";
 
 import { UserAccountManagerProvider } from "../components/UserAccountManagerProvider";
@@ -19,6 +18,7 @@ it("allows user to reset their password with a valid token", async () => {
 
   await tick();
 
+  // With no password entered, form validation fails with the required field
   const saveButton = screen.getByRole("button", { name: /submit/i });
   fireEvent.click(saveButton);
 
@@ -26,13 +26,42 @@ it("allows user to reset their password with a valid token", async () => {
 
   expect(mockUserAccountClient.resetPassword).toHaveBeenCalledTimes(0);
 
-  fireEvent.change(screen.getByLabelText(/password/i), {
+  fireEvent.change(screen.getByLabelText(/newPasswordLabel/), {
     target: { value: "newpass" },
   });
+  await tick();
+
   fireEvent.click(saveButton);
 
   await tick();
 
+  // With only one password entered, form validation fails with the required field
+  expect(mockUserAccountClient.resetPassword).toHaveBeenCalledTimes(0);
+
+  fireEvent.change(screen.getByLabelText(/retypePasswordLabel/), {
+    target: { value: "mismatch" },
+  });
+
+  await tick();
+
+  fireEvent.click(saveButton);
+
+  await tick();
+
+  // Mismatched passwords should also fail validation
+  expect(mockUserAccountClient.resetPassword).toHaveBeenCalledTimes(0);
+
+  fireEvent.change(screen.getByLabelText(/retypePasswordLabel/), {
+    target: { value: "newpass" },
+  });
+
+  await tick();
+
+  fireEvent.click(saveButton);
+
+  await tick();
+
+  // When both passwords match, form should be submitted
   expect(mockUserAccountClient.resetPassword).toHaveBeenCalledTimes(1);
   expect(mockUserAccountClient.resetPassword).toHaveBeenCalledWith({
     token: "foo",
@@ -55,7 +84,10 @@ it("shows an error if the token wasn't validated", async () => {
 
   await tick();
 
-  fireEvent.change(screen.getByLabelText(/password/i), {
+  fireEvent.change(screen.getByLabelText(/newPassword/), {
+    target: { value: "newpass" },
+  });
+  fireEvent.change(screen.getByLabelText(/retypePassword/), {
     target: { value: "newpass" },
   });
 

--- a/client/src/__tests__/ResetAccountPassword.test.tsx
+++ b/client/src/__tests__/ResetAccountPassword.test.tsx
@@ -1,11 +1,9 @@
-import { render, screen, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom/extend-expect";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-
 import { UserAccountManagerProvider } from "../components/UserAccountManagerProvider";
-import { tick, mockUserAccountClient } from "./utils";
-
 import { ResetAccountPassword } from "../pages/ResetAccountPassword/ResetAccountPassword";
+import { mockUserAccountClient, tick } from "./utils";
 
 it("allows user to reset their password with a valid token", async () => {
   render(

--- a/client/src/__tests__/VerifyAccount.test.tsx
+++ b/client/src/__tests__/VerifyAccount.test.tsx
@@ -1,11 +1,9 @@
-import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/extend-expect";
+import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-
 import { UserAccountManagerProvider } from "../components/UserAccountManagerProvider";
-import { tick, mockUserAccountClient } from "./utils";
-
 import { VerifyAccount } from "../pages/VerifyAccount";
+import { mockUserAccountClient, tick } from "./utils";
 
 it("verifies the given token with the server", async () => {
   render(

--- a/client/src/__tests__/VerifyAccount.test.tsx
+++ b/client/src/__tests__/VerifyAccount.test.tsx
@@ -1,6 +1,5 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/extend-expect";
-import React from "react";
 import { MemoryRouter } from "react-router-dom";
 
 import { UserAccountManagerProvider } from "../components/UserAccountManagerProvider";

--- a/client/src/__tests__/utils.ts
+++ b/client/src/__tests__/utils.ts
@@ -1,5 +1,4 @@
 import { act } from "@testing-library/react";
-import { UserAccountManager } from "../services/account";
 
 /**
  * Mock account management REST client

--- a/client/src/components/Breadcrumb/Breadcrumbs.tsx
+++ b/client/src/components/Breadcrumb/Breadcrumbs.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Link } from "react-router-dom";
 import { Breadcrumb } from "antd";
 import { normalRoutes } from "../../router/routes";

--- a/client/src/components/Breadcrumb/Breadcrumbs.tsx
+++ b/client/src/components/Breadcrumb/Breadcrumbs.tsx
@@ -1,7 +1,7 @@
-import { Link } from "react-router-dom";
 import { Breadcrumb } from "antd";
-import { normalRoutes } from "../../router/routes";
+import { Link } from "react-router-dom";
 import useBreadcrumbs from "use-react-router-breadcrumbs";
+import { normalRoutes } from "../../router/routes";
 
 const BreadCrumb = () => {
   /**

--- a/client/src/components/Error/ErrorFallback.tsx
+++ b/client/src/components/Error/ErrorFallback.tsx
@@ -1,5 +1,5 @@
-import { ApolloError } from "apollo-server";
 import { Alert } from "antd";
+import { ApolloError } from "apollo-server";
 import "./ErrorFallback.css";
 
 interface ErrorProps {

--- a/client/src/components/Error/ErrorFallback.tsx
+++ b/client/src/components/Error/ErrorFallback.tsx
@@ -1,5 +1,4 @@
 import { ApolloError } from "apollo-server";
-import React from "react";
 import { Alert } from "antd";
 import "./ErrorFallback.css";
 

--- a/client/src/components/Loading/Loading.tsx
+++ b/client/src/components/Loading/Loading.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Spin } from "antd";
 import "./Loading.css";
 

--- a/client/src/components/Message.tsx
+++ b/client/src/components/Message.tsx
@@ -1,7 +1,6 @@
-import { CSSProperties, ReactNode } from "react";
 import { message } from "antd";
-import { ArgsProps } from "antd/lib/message";
-import { ConfigOnClose } from "antd/lib/message";
+import { ArgsProps, ConfigOnClose } from "antd/lib/message";
+import { CSSProperties, ReactNode } from "react";
 
 /**
  * Default configuration for messages

--- a/client/src/components/Message.tsx
+++ b/client/src/components/Message.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, isValidElement, ReactNode } from "react";
+import { CSSProperties, ReactNode } from "react";
 import { message } from "antd";
 import { ArgsProps } from "antd/lib/message";
 import { ConfigOnClose } from "antd/lib/message";

--- a/client/src/components/NewStringInput.tsx
+++ b/client/src/components/NewStringInput.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { PlusCircleOutlined } from "@ant-design/icons";
 import { Input, Button } from "antd";
 

--- a/client/src/components/NewStringInput.tsx
+++ b/client/src/components/NewStringInput.tsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
 import { PlusCircleOutlined } from "@ant-design/icons";
-import { Input, Button } from "antd";
+import { Button, Input } from "antd";
+import { useState } from "react";
 
 /**
  * Props for the NewStringInput component.

--- a/client/src/graphql/__mocks__/AutoMockProvider.tsx
+++ b/client/src/graphql/__mocks__/AutoMockProvider.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import {
   ApolloClient,
   ApolloLink,
@@ -6,7 +5,7 @@ import {
   Observable,
   split,
 } from "@apollo/client";
-import { makeExecutableSchema, IMocks, mergeResolvers } from "graphql-tools";
+import { makeExecutableSchema, mergeResolvers } from "graphql-tools";
 import { printSchema, buildClientSchema } from "graphql/utilities";
 import introspectionResult from "../../schema.json";
 import { GraphQLError } from "graphql";

--- a/client/src/graphql/__mocks__/AutoMockProvider.tsx
+++ b/client/src/graphql/__mocks__/AutoMockProvider.tsx
@@ -39,7 +39,7 @@ const autoMockedClient = (
   addMockFunctionsToSchema({ schema, mocks });
 
   // Define errors
-  const errorLink = new ApolloLink((operation) => {
+  const errorLink = new ApolloLink(() => {
     return new Observable((observer) => {
       observer.next({
         errors: graphQLError,

--- a/client/src/graphql/__mocks__/AutoMockProvider.tsx
+++ b/client/src/graphql/__mocks__/AutoMockProvider.tsx
@@ -5,12 +5,12 @@ import {
   Observable,
   split,
 } from "@apollo/client";
-import { makeExecutableSchema, mergeResolvers } from "graphql-tools";
-import { printSchema, buildClientSchema } from "graphql/utilities";
-import introspectionResult from "../../schema.json";
-import { GraphQLError } from "graphql";
 import { SchemaLink } from "@apollo/client/link/schema";
 import { addMockFunctionsToSchema } from "apollo-server";
+import { GraphQLError } from "graphql";
+import { makeExecutableSchema, mergeResolvers } from "graphql-tools";
+import { buildClientSchema, printSchema } from "graphql/utilities";
+import introspectionResult from "../../schema.json";
 import { mockResolvers } from "./MockResolvers";
 
 /**

--- a/client/src/graphql/__mocks__/MockResolvers.tsx
+++ b/client/src/graphql/__mocks__/MockResolvers.tsx
@@ -171,19 +171,18 @@ export const mockResolvers = {
   Query: () => ({
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    dataset: (parent, args, ctx, info) => datasets.get(args.id),
+    dataset: (parent, args) => datasets.get(args.id),
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     user: () => users.get("1"),
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    record: (parent, args, ctx, info) =>
-      recordsData.find((item) => item.id === args.id),
+    record: (parent, args) => recordsData.find((item) => item.id === args.id),
   }),
   Mutation: () => ({
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    deleteRecord: (parent, args, ctx, info) => {
+    deleteRecord: (parent, args) => {
       const recordToRemove = recordsData
         .map((item) => item.id)
         .indexOf(args.id);
@@ -198,7 +197,7 @@ export const mockResolvers = {
     },
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    updateRecord: (parent, args, ctx, info) => {
+    updateRecord: () => {
       const recordToUpdate = recordsData[0];
 
       return { input: recordToUpdate };

--- a/client/src/graphql/__mocks__/gql-mock-server.ts
+++ b/client/src/graphql/__mocks__/gql-mock-server.ts
@@ -1,7 +1,7 @@
 import { ApolloServer, UserInputError } from "apollo-server";
+import fake from "casual";
 import { buildClientSchema } from "graphql";
 import introspectedSchema from "../../schema.json";
-import fake from "casual";
 
 fake.seed(123);
 

--- a/client/src/graphql/__mocks__/gql-mock-server.ts
+++ b/client/src/graphql/__mocks__/gql-mock-server.ts
@@ -70,15 +70,15 @@ const mockTypes = {
   Query: () => ({
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    dataset: (parent, args, ctx, info) => datasets.get(args.id) || {},
+    dataset: (parent, args) => datasets.get(args.id) || {},
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    user: (parent, args, ctx, info) => users.get(args.id) || {},
+    user: (parent, args) => users.get(args.id) || {},
   }),
   Mutation: () => ({
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    upsertRecord: (parent, args, ctx, info) => {
+    upsertRecord: (parent, args) => {
       args.input.id = fake.uuid;
       args.input.data.forEach((element: { id: string }) => {
         element.id = fake.uuid;
@@ -92,7 +92,7 @@ const mockTypes = {
     },
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    deleteRecord: (parent, args, ctx, info) => {
+    deleteRecord: (parent, args) => {
       const recordToRemove = recordsData
         .map((item) => item.id)
         .indexOf(args.id);

--- a/client/src/graphql/hooks/useQueryWithErrorHandling.ts
+++ b/client/src/graphql/hooks/useQueryWithErrorHandling.ts
@@ -1,9 +1,9 @@
 import {
-  useQuery,
   ApolloQueryResult,
-  OperationVariables,
   DocumentNode,
+  OperationVariables,
   QueryHookOptions,
+  useQuery,
 } from "@apollo/client";
 
 /**

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,13 +1,13 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
+    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace;
 }

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -1,22 +1,22 @@
-import React, { Suspense } from "react";
-import ReactDOM from "react-dom";
-import "./services/i18next";
-import App from "./App";
-import reportWebVitals from "./reportWebVitals";
 import {
   ApolloClient,
   ApolloProvider,
-  NormalizedCacheObject,
-  InMemoryCache,
-  HttpLink,
   from,
+  HttpLink,
+  InMemoryCache,
+  NormalizedCacheObject,
 } from "@apollo/client";
 import { onError } from "@apollo/client/link/error";
+import React, { Suspense } from "react";
+import ReactDOM from "react-dom";
+import App from "./App";
 import { AuthProvider } from "./components/AuthProvider";
-import { Auth } from "./services/auth";
-import { UserAccountManagerProvider } from "./components/UserAccountManagerProvider";
-import * as account from "./services/account";
 import { Loading } from "./components/Loading/Loading";
+import { UserAccountManagerProvider } from "./components/UserAccountManagerProvider";
+import reportWebVitals from "./reportWebVitals";
+import * as account from "./services/account";
+import { Auth } from "./services/auth";
+import "./services/i18next";
 
 const errorLink = onError(({ graphQLErrors, networkError }) => {
   if (graphQLErrors)

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -10,7 +10,6 @@ import {
   InMemoryCache,
   HttpLink,
   from,
-  ApolloLink,
 } from "@apollo/client";
 import { onError } from "@apollo/client/link/error";
 import { AuthProvider } from "./components/AuthProvider";
@@ -41,9 +40,7 @@ const cache = new InMemoryCache({
     Dataset: {
       fields: {
         records: {
-          merge(existing = [], incoming: any[]) {
-            return [...incoming];
-          },
+          merge: false,
         },
       },
     },

--- a/client/src/layout/AppHeader.tsx
+++ b/client/src/layout/AppHeader.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import "./AppHeader.css";
 import logo from "../assets/5050logo.jpg";
 import { Layout, Avatar, Col, Row, Button } from "antd";

--- a/client/src/layout/AppHeader.tsx
+++ b/client/src/layout/AppHeader.tsx
@@ -1,9 +1,9 @@
-import "./AppHeader.css";
-import logo from "../assets/5050logo.jpg";
-import { Layout, Avatar, Col, Row, Button } from "antd";
-import { UserOutlined, LogoutOutlined } from "@ant-design/icons";
+import { LogoutOutlined, UserOutlined } from "@ant-design/icons";
+import { Avatar, Button, Col, Layout, Row } from "antd";
 import { Link, useHistory } from "react-router-dom";
+import logo from "../assets/5050logo.jpg";
 import { useAuth } from "../components/AuthProvider";
+import "./AppHeader.css";
 
 const { Header } = Layout;
 

--- a/client/src/layout/AppSidebar.tsx
+++ b/client/src/layout/AppSidebar.tsx
@@ -1,17 +1,17 @@
-import { Layout, Menu } from "antd";
 import {
-  DatabaseOutlined,
-  TeamOutlined,
   BarChartOutlined,
-  UserSwitchOutlined,
+  DatabaseOutlined,
   TableOutlined,
+  TeamOutlined,
+  UserSwitchOutlined,
 } from "@ant-design/icons";
+import { useQuery } from "@apollo/client";
+import { Layout, Menu } from "antd";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
+import { useAuth } from "../components/AuthProvider";
 import { GetUser, GetUserVariables } from "../graphql/__generated__/getUser";
 import { GET_USER } from "../graphql/__queries__/GetUser.gql";
-import { useQuery } from "@apollo/client";
-import { useAuth } from "../components/AuthProvider";
 
 const { SubMenu } = Menu;
 const { Sider } = Layout;

--- a/client/src/layout/AppSidebar.tsx
+++ b/client/src/layout/AppSidebar.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Layout, Menu } from "antd";
 import {
   DatabaseOutlined,
@@ -13,7 +12,6 @@ import { GetUser, GetUserVariables } from "../graphql/__generated__/getUser";
 import { GET_USER } from "../graphql/__queries__/GetUser.gql";
 import { useQuery } from "@apollo/client";
 import { useAuth } from "../components/AuthProvider";
-import { ErrorFallback } from "../components/Error/ErrorFallback";
 
 const { SubMenu } = Menu;
 const { Sider } = Layout;
@@ -27,15 +25,12 @@ interface Dataset {
  * Sidebar content for normal (non-admin) users.
  */
 export const AppNormalUserSidebarMenu = () => {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const userId = useAuth().getUserId();
 
-  const { data, loading, error } = useQuery<GetUser, GetUserVariables>(
-    GET_USER,
-    {
-      variables: { id: userId },
-    }
-  );
+  const { data, loading } = useQuery<GetUser, GetUserVariables>(GET_USER, {
+    variables: { id: userId },
+  });
 
   const sidebarPrograms = data?.user?.teams.flatMap((team) =>
     team.programs.map((program) => {
@@ -99,7 +94,7 @@ export const AppNormalUserSidebarMenu = () => {
  * Sidebar content for admin users.
  */
 export const AppAdminSidebarMenu = () => {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   return (
     <Menu mode="inline" role="menubar">
       <Menu.Item key="alldata" icon={<DatabaseOutlined />} role="menuitem">

--- a/client/src/pages/Admin/CreateProgram.tsx
+++ b/client/src/pages/Admin/CreateProgram.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useApolloClient } from "@apollo/client";
 import { useHistory } from "react-router-dom";
 import { useTranslation } from "react-i18next";
@@ -9,19 +9,12 @@ import { useQueryWithErrorHandling } from "../../graphql/hooks/useQueryWithError
 
 import {
   AdminGetProgram,
-  AdminGetProgram_program_targets,
   AdminGetProgramVariables,
 } from "../../graphql/__generated__/AdminGetProgram";
 import { ADMIN_GET_PROGRAM } from "../../graphql/__queries__/AdminGetProgram.gql";
-import {
-  AdminGetAllTeams,
-  AdminGetAllTeams_teams,
-} from "../../graphql/__generated__/AdminGetAllTeams";
+import { AdminGetAllTeams } from "../../graphql/__generated__/AdminGetAllTeams";
 import { ADMIN_GET_ALL_TEAMS } from "../../graphql/__queries__/AdminGetAllTeams.gql";
-import {
-  AdminGetAllPrograms,
-  AdminGetAllPrograms_programs,
-} from "../../graphql/__generated__/AdminGetAllPrograms";
+import { AdminGetAllPrograms } from "../../graphql/__generated__/AdminGetAllPrograms";
 import { ADMIN_GET_ALL_PROGRAMS } from "../../graphql/__queries__/AdminGetAllPrograms.gql";
 import { CreateProgramInput } from "../../graphql/__generated__/globalTypes";
 import {
@@ -71,7 +64,7 @@ export const CreateProgram = ({ form }: CreateProgramProps) => {
     }
   );
 
-  if (teamsResponse.loading) {
+  if (teamsResponse.loading || saving) {
     return <Loading />;
   }
 

--- a/client/src/pages/Admin/CreateProgram.tsx
+++ b/client/src/pages/Admin/CreateProgram.tsx
@@ -1,27 +1,25 @@
-import { useState } from "react";
 import { useApolloClient } from "@apollo/client";
-import { useHistory } from "react-router-dom";
+import { Alert, Form, FormInstance, Input, message, Select } from "antd";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Alert, Form, Select, Input, FormInstance, message } from "antd";
-
+import { useHistory } from "react-router-dom";
 import { Loading } from "../../components/Loading/Loading";
 import { useQueryWithErrorHandling } from "../../graphql/hooks/useQueryWithErrorHandling";
-
-import {
-  AdminGetProgram,
-  AdminGetProgramVariables,
-} from "../../graphql/__generated__/AdminGetProgram";
-import { ADMIN_GET_PROGRAM } from "../../graphql/__queries__/AdminGetProgram.gql";
-import { AdminGetAllTeams } from "../../graphql/__generated__/AdminGetAllTeams";
-import { ADMIN_GET_ALL_TEAMS } from "../../graphql/__queries__/AdminGetAllTeams.gql";
-import { AdminGetAllPrograms } from "../../graphql/__generated__/AdminGetAllPrograms";
-import { ADMIN_GET_ALL_PROGRAMS } from "../../graphql/__queries__/AdminGetAllPrograms.gql";
-import { CreateProgramInput } from "../../graphql/__generated__/globalTypes";
 import {
   AdminCreateProgram,
   AdminCreateProgramVariables,
 } from "../../graphql/__generated__/AdminCreateProgram";
+import { AdminGetAllPrograms } from "../../graphql/__generated__/AdminGetAllPrograms";
+import { AdminGetAllTeams } from "../../graphql/__generated__/AdminGetAllTeams";
+import {
+  AdminGetProgram,
+  AdminGetProgramVariables,
+} from "../../graphql/__generated__/AdminGetProgram";
+import { CreateProgramInput } from "../../graphql/__generated__/globalTypes";
 import { ADMIN_CREATE_PROGRAM } from "../../graphql/__mutations__/AdminCreateProgram.gql";
+import { ADMIN_GET_ALL_PROGRAMS } from "../../graphql/__queries__/AdminGetAllPrograms.gql";
+import { ADMIN_GET_ALL_TEAMS } from "../../graphql/__queries__/AdminGetAllTeams.gql";
+import { ADMIN_GET_PROGRAM } from "../../graphql/__queries__/AdminGetProgram.gql";
 
 /**
  * Values set by the UI form.

--- a/client/src/pages/Admin/CreateUser.tsx
+++ b/client/src/pages/Admin/CreateUser.tsx
@@ -1,8 +1,8 @@
-import { useHistory } from "react-router-dom";
+import { Form, FormInstance, Input, message } from "antd";
 import { useTranslation } from "react-i18next";
-import { Form, Input, FormInstance, message } from "antd";
-import { CreateUserFormValues } from "../../services/account";
+import { useHistory } from "react-router-dom";
 import { useUserAccountManager } from "../../components/UserAccountManagerProvider";
+import { CreateUserFormValues } from "../../services/account";
 
 export type CreateUserProps = {
   /**

--- a/client/src/pages/Admin/CreateUser.tsx
+++ b/client/src/pages/Admin/CreateUser.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useHistory } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { Form, Input, FormInstance, message } from "antd";

--- a/client/src/pages/Admin/EditProgram.tsx
+++ b/client/src/pages/Admin/EditProgram.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { useTranslation } from "react-i18next";
 import { useParams, useHistory } from "react-router-dom";
 
@@ -11,7 +11,6 @@ import {
 import {
   Alert,
   List,
-  Space,
   Col,
   Row,
   Typography,
@@ -23,7 +22,6 @@ import {
   InputNumber,
   Button,
   Popconfirm,
-  message,
 } from "antd";
 
 import { useQueryWithErrorHandling } from "../../graphql/hooks/useQueryWithErrorHandling";
@@ -36,10 +34,7 @@ import {
   AdminGetProgramVariables,
 } from "../../graphql/__generated__/AdminGetProgram";
 import { ADMIN_GET_PROGRAM } from "../../graphql/__queries__/AdminGetProgram.gql";
-import {
-  AdminGetAllTeams,
-  AdminGetAllTeams_teams,
-} from "../../graphql/__generated__/AdminGetAllTeams";
+import { AdminGetAllTeams } from "../../graphql/__generated__/AdminGetAllTeams";
 import { ADMIN_GET_ALL_TEAMS } from "../../graphql/__queries__/AdminGetAllTeams.gql";
 
 import { AdminGetAllCategories } from "../../graphql/__generated__/AdminGetAllCategories";
@@ -274,7 +269,7 @@ export const EditProgram = () => {
         <Form.List name="targets">
           {(targetFields, targetOps) => (
             <>
-              {targetFields.map((targetField, index) => (
+              {targetFields.map((targetField) => (
                 <React.Fragment key={targetField.key}>
                   <Row>
                     <Col offset={2} span={20}>
@@ -438,7 +433,7 @@ export const EditProgram = () => {
                                       ]),
                                     }
                                   )}
-                                  onAdd={(newSegment, event) => {
+                                  onAdd={(newSegment) => {
                                     if (newSegment) {
                                       segmentOps.add({
                                         categoryValueName: newSegment,

--- a/client/src/pages/Admin/EditProgram.tsx
+++ b/client/src/pages/Admin/EditProgram.tsx
@@ -1,52 +1,47 @@
-import React from "react";
-import { useTranslation } from "react-i18next";
-import { useParams, useHistory } from "react-router-dom";
-
 import {
-  PlusCircleOutlined,
   CloseCircleOutlined,
-  SaveOutlined,
   DeleteOutlined,
+  PlusCircleOutlined,
+  SaveOutlined,
 } from "@ant-design/icons";
 import {
   Alert,
-  List,
+  Button,
   Col,
-  Row,
-  Typography,
-  Select,
   Divider,
-  PageHeader,
   Form,
   Input,
   InputNumber,
-  Button,
+  List,
+  PageHeader,
   Popconfirm,
+  Row,
+  Select,
+  Typography,
 } from "antd";
-
-import { useQueryWithErrorHandling } from "../../graphql/hooks/useQueryWithErrorHandling";
-
-import { NewStringInput } from "../../components/NewStringInput";
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { useHistory, useParams } from "react-router-dom";
 import { Loading } from "../../components/Loading/Loading";
+import { NewStringInput } from "../../components/NewStringInput";
+import { useQueryWithErrorHandling } from "../../graphql/hooks/useQueryWithErrorHandling";
+import { AdminGetAllCategories } from "../../graphql/__generated__/AdminGetAllCategories";
+import { AdminGetAllTeams } from "../../graphql/__generated__/AdminGetAllTeams";
 import {
   AdminGetProgram,
-  AdminGetProgram_program_targets,
   AdminGetProgramVariables,
+  AdminGetProgram_program_targets,
 } from "../../graphql/__generated__/AdminGetProgram";
-import { ADMIN_GET_PROGRAM } from "../../graphql/__queries__/AdminGetProgram.gql";
-import { AdminGetAllTeams } from "../../graphql/__generated__/AdminGetAllTeams";
-import { ADMIN_GET_ALL_TEAMS } from "../../graphql/__queries__/AdminGetAllTeams.gql";
-
-import { AdminGetAllCategories } from "../../graphql/__generated__/AdminGetAllCategories";
 import { ADMIN_GET_ALL_CATEGORIES } from "../../graphql/__queries__/AdminGetAllCategories.gql";
-
+import { ADMIN_GET_ALL_TEAMS } from "../../graphql/__queries__/AdminGetAllTeams.gql";
+import { ADMIN_GET_PROGRAM } from "../../graphql/__queries__/AdminGetProgram.gql";
 import {
-  ProgramUpdateFormValues,
   CategoryTarget,
   CategoryTargetSegment,
-  useSave,
-  useRestore,
+  ProgramUpdateFormValues,
   useDeactivate,
+  useRestore,
+  useSave,
 } from "./programHooks";
 
 /**

--- a/client/src/pages/Admin/EditUser.tsx
+++ b/client/src/pages/Admin/EditUser.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { useParams, useHistory } from "react-router-dom";
 import { useQuery, ApolloQueryResult } from "@apollo/client";
 import { useTranslation, TFunction } from "react-i18next";
@@ -9,7 +9,6 @@ import {
   Button,
   Input,
   Divider,
-  List,
   Checkbox,
   Select,
   Row,
@@ -21,19 +20,9 @@ import {
 import { ADMIN_GET_USER } from "../../graphql/__queries__/AdminGetUser.gql";
 import { ADMIN_GET_ALL_TEAMS } from "../../graphql/__queries__/AdminGetAllTeams.gql";
 import { ADMIN_GET_ALL_ROLES } from "../../graphql/__queries__/AdminGetAllRoles.gql";
-import {
-  AdminGetAllTeams,
-  AdminGetAllTeams_teams,
-} from "../../graphql/__generated__/AdminGetAllTeams";
-import {
-  AdminGetAllRoles,
-  AdminGetAllRoles_roles,
-} from "../../graphql/__generated__/AdminGetAllRoles";
-import {
-  AdminGetUser,
-  AdminGetUser_user,
-  AdminGetUser_user_teams,
-} from "../../graphql/__generated__/AdminGetUser";
+import { AdminGetAllTeams } from "../../graphql/__generated__/AdminGetAllTeams";
+import { AdminGetAllRoles } from "../../graphql/__generated__/AdminGetAllRoles";
+import { AdminGetUser } from "../../graphql/__generated__/AdminGetUser";
 import { Loading } from "../../components/Loading/Loading";
 import { EditUserFormData } from "../../services/account";
 import { useUserAccountManager } from "../../components/UserAccountManagerProvider";
@@ -109,7 +98,7 @@ const useAdminUserQueries = (id: string, t: TFunction) => {
     /**
      * Container for any error that occurred while running queries.
      */
-    error: userResponse.error || teamsResponse.error || rolesResponse.error,
+    error: userError || teamsError || rolesError,
   };
 };
 
@@ -152,7 +141,6 @@ const useSaveUser = (id: string, t: TFunction) => {
  * Hook for user deletion request and state.
  */
 const useDeleteUser = (userId: string, refresh: () => void, t: TFunction) => {
-  const history = useHistory();
   const account = useUserAccountManager();
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<Error | null>(null);
@@ -194,7 +182,7 @@ const useDeleteUser = (userId: string, refresh: () => void, t: TFunction) => {
 /**
  * Hook for the query to restore a user, with associated state.
  */
-const useRestoreUser = (userId: string, refresh: () => void, t: TFunction) => {
+const useRestoreUser = (userId: string, refresh: () => void) => {
   const account = useUserAccountManager();
   const [restoring, setRestoring] = useState(false);
   const [restoreError, setRestoreError] = useState<Error | null>(null);
@@ -250,11 +238,7 @@ export const EditUser = () => {
     refresh,
     t
   );
-  const { restoring, restoreError, restoreUser } = useRestoreUser(
-    userId,
-    refresh,
-    t
-  );
+  const { restoreError, restoreUser } = useRestoreUser(userId, refresh);
 
   // TODO: update error and loading components
   if (loading) {
@@ -264,10 +248,6 @@ export const EditUser = () => {
   if (error) {
     return <div>An error occurred: {error}</div>;
   }
-
-  // Get the team object given its ID.
-  const getTeamById = (id: string) =>
-    teamsResponse.data!.teams.find((t) => t.id === id);
 
   // Initial values of the form fields.
   const initialFormState: EditUserFormData = {

--- a/client/src/pages/Admin/EditUser.tsx
+++ b/client/src/pages/Admin/EditUser.tsx
@@ -1,31 +1,30 @@
-import React, { useState } from "react";
-import { useParams, useHistory } from "react-router-dom";
-import { useQuery, ApolloQueryResult } from "@apollo/client";
-import { useTranslation, TFunction } from "react-i18next";
 import { DeleteOutlined, SaveOutlined } from "@ant-design/icons";
+import { ApolloQueryResult, useQuery } from "@apollo/client";
 import {
   Alert,
-  Form,
   Button,
-  Input,
-  Divider,
   Checkbox,
-  Select,
-  Row,
-  PageHeader,
-  Modal,
+  Divider,
+  Form,
+  Input,
   message,
+  Modal,
+  PageHeader,
+  Row,
+  Select,
 } from "antd";
-
-import { ADMIN_GET_USER } from "../../graphql/__queries__/AdminGetUser.gql";
-import { ADMIN_GET_ALL_TEAMS } from "../../graphql/__queries__/AdminGetAllTeams.gql";
-import { ADMIN_GET_ALL_ROLES } from "../../graphql/__queries__/AdminGetAllRoles.gql";
-import { AdminGetAllTeams } from "../../graphql/__generated__/AdminGetAllTeams";
-import { AdminGetAllRoles } from "../../graphql/__generated__/AdminGetAllRoles";
-import { AdminGetUser } from "../../graphql/__generated__/AdminGetUser";
+import React, { useState } from "react";
+import { TFunction, useTranslation } from "react-i18next";
+import { useHistory, useParams } from "react-router-dom";
 import { Loading } from "../../components/Loading/Loading";
-import { EditUserFormData } from "../../services/account";
 import { useUserAccountManager } from "../../components/UserAccountManagerProvider";
+import { AdminGetAllRoles } from "../../graphql/__generated__/AdminGetAllRoles";
+import { AdminGetAllTeams } from "../../graphql/__generated__/AdminGetAllTeams";
+import { AdminGetUser } from "../../graphql/__generated__/AdminGetUser";
+import { ADMIN_GET_ALL_ROLES } from "../../graphql/__queries__/AdminGetAllRoles.gql";
+import { ADMIN_GET_ALL_TEAMS } from "../../graphql/__queries__/AdminGetAllTeams.gql";
+import { ADMIN_GET_USER } from "../../graphql/__queries__/AdminGetUser.gql";
+import { EditUserFormData } from "../../services/account";
 
 /**
  * Check that GraphQL query response doesn't contain an error.

--- a/client/src/pages/Admin/ProgramList.tsx
+++ b/client/src/pages/Admin/ProgramList.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 

--- a/client/src/pages/Admin/ProgramList.tsx
+++ b/client/src/pages/Admin/ProgramList.tsx
@@ -1,22 +1,20 @@
+import {
+  AppstoreAddOutlined,
+  CheckCircleOutlined,
+  EditOutlined,
+} from "@ant-design/icons";
+import { Button, Form, Modal, PageHeader, Table } from "antd";
+import { ColumnsType } from "antd/lib/table";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
-
-import {
-  CheckCircleOutlined,
-  AppstoreAddOutlined,
-  EditOutlined,
-} from "@ant-design/icons";
-import { Button, PageHeader, Table, Form, Modal } from "antd";
-import { ColumnsType } from "antd/lib/table";
-
-import { CreateProgram, CreateProgramFormValues } from "./CreateProgram";
 import { useQueryWithErrorHandling } from "../../graphql/hooks/useQueryWithErrorHandling";
 import {
   AdminGetAllPrograms,
   AdminGetAllPrograms_programs,
 } from "../../graphql/__generated__/AdminGetAllPrograms";
 import { ADMIN_GET_ALL_PROGRAMS } from "../../graphql/__queries__/AdminGetAllPrograms.gql";
+import { CreateProgram, CreateProgramFormValues } from "./CreateProgram";
 
 /**
  * Render a cell in the table for categories tracked by a dataset.

--- a/client/src/pages/Admin/UserList.tsx
+++ b/client/src/pages/Admin/UserList.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useQuery } from "@apollo/client";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";

--- a/client/src/pages/Admin/UserList.tsx
+++ b/client/src/pages/Admin/UserList.tsx
@@ -1,22 +1,22 @@
-import { useState } from "react";
-import { useQuery } from "@apollo/client";
-import { useTranslation } from "react-i18next";
-import { Link } from "react-router-dom";
-import { Button, Modal, Table, Form, PageHeader } from "antd";
-import { ColumnsType } from "antd/lib/table";
 import {
-  EditOutlined,
   CheckCircleOutlined,
+  EditOutlined,
   UserAddOutlined,
 } from "@ant-design/icons";
-import { GET_USER_LIST } from "../../graphql/__queries__/GetUserList.gql";
+import { useQuery } from "@apollo/client";
+import { Button, Form, Modal, PageHeader, Table } from "antd";
+import { ColumnsType } from "antd/lib/table";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
+import { Loading } from "../../components/Loading/Loading";
 import {
   GetUserList,
   GetUserList_users,
 } from "../../graphql/__generated__/GetUserList";
-import { Loading } from "../../components/Loading/Loading";
-import { CreateUser } from "./CreateUser";
+import { GET_USER_LIST } from "../../graphql/__queries__/GetUserList.gql";
 import { CreateUserFormValues } from "../../services/account";
+import { CreateUser } from "./CreateUser";
 
 /**
  * Index of all users in the organization.

--- a/client/src/pages/Admin/programHooks.ts
+++ b/client/src/pages/Admin/programHooks.ts
@@ -1,24 +1,23 @@
-import { useState } from "react";
-import { useApolloClient, ApolloClient, FetchResult } from "@apollo/client";
-import { TargetInput } from "../../graphql/__generated__/globalTypes";
-import { useTranslation } from "react-i18next";
+import { ApolloClient, FetchResult, useApolloClient } from "@apollo/client";
 import { message } from "antd";
-
-import {
-  AdminUpdateProgram,
-  AdminUpdateProgramVariables,
-} from "../../graphql/__generated__/AdminUpdateProgram";
-import { ADMIN_UPDATE_PROGRAM } from "../../graphql/__mutations__/AdminUpdateProgram.gql";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import {
   AdminDeleteProgram,
   AdminDeleteProgramVariables,
 } from "../../graphql/__generated__/AdminDeleteProgram";
-import { ADMIN_DELETE_PROGRAM } from "../../graphql/__mutations__/AdminDeleteProgram.gql";
 import {
   AdminRestoreProgram,
   AdminRestoreProgramVariables,
 } from "../../graphql/__generated__/AdminRestoreProgram";
+import {
+  AdminUpdateProgram,
+  AdminUpdateProgramVariables,
+} from "../../graphql/__generated__/AdminUpdateProgram";
+import { TargetInput } from "../../graphql/__generated__/globalTypes";
+import { ADMIN_DELETE_PROGRAM } from "../../graphql/__mutations__/AdminDeleteProgram.gql";
 import { ADMIN_RESTORE_PROGRAM } from "../../graphql/__mutations__/AdminRestoreProgram.gql";
+import { ADMIN_UPDATE_PROGRAM } from "../../graphql/__mutations__/AdminUpdateProgram.gql";
 
 /**
  * Form values filled out by the UI for editing datasetes.

--- a/client/src/pages/DataEntry/DataEntry.tsx
+++ b/client/src/pages/DataEntry/DataEntry.tsx
@@ -1,5 +1,5 @@
 import { Button, Result, Typography } from "antd";
-import React, { useState } from "react";
+import { useState } from "react";
 import "./DataEntry.css";
 import { DataEntryAggregateDataEntryForm } from "./DataEntryAggregateDataEntryForm";
 import { Link, useHistory, useParams } from "react-router-dom";

--- a/client/src/pages/DataEntry/DataEntry.tsx
+++ b/client/src/pages/DataEntry/DataEntry.tsx
@@ -1,21 +1,21 @@
+import { DashboardTwoTone, PlusCircleTwoTone } from "@ant-design/icons";
+import { useQuery } from "@apollo/client";
 import { Button, Result, Typography } from "antd";
 import { useState } from "react";
-import "./DataEntry.css";
-import { DataEntryAggregateDataEntryForm } from "./DataEntryAggregateDataEntryForm";
-import { Link, useHistory, useParams } from "react-router-dom";
-import { PlusCircleTwoTone, DashboardTwoTone } from "@ant-design/icons";
 import { useTranslation } from "react-i18next";
-import { useQuery } from "@apollo/client";
-import {
-  GetRecord,
-  GetRecordVariables,
-} from "../../graphql/__generated__/GetRecord";
-import { GET_RECORD } from "../../graphql/__queries__/GetRecord.gql";
+import { Link, useHistory, useParams } from "react-router-dom";
 import {
   GetDataset,
   GetDatasetVariables,
 } from "../../graphql/__generated__/GetDataset";
+import {
+  GetRecord,
+  GetRecordVariables,
+} from "../../graphql/__generated__/GetRecord";
 import { GET_DATASET } from "../../graphql/__queries__/GetDataset.gql";
+import { GET_RECORD } from "../../graphql/__queries__/GetRecord.gql";
+import "./DataEntry.css";
+import { DataEntryAggregateDataEntryForm } from "./DataEntryAggregateDataEntryForm";
 
 const { Title } = Typography;
 

--- a/client/src/pages/DataEntry/DataEntryAggregateDataEntryForm.tsx
+++ b/client/src/pages/DataEntry/DataEntryAggregateDataEntryForm.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   ChangeEvent,
   Dispatch,
   FormEvent,

--- a/client/src/pages/DataEntry/DataEntryAggregateDataEntryForm.tsx
+++ b/client/src/pages/DataEntry/DataEntryAggregateDataEntryForm.tsx
@@ -1,3 +1,6 @@
+import { CloseSquareFilled, SaveOutlined } from "@ant-design/icons";
+import { Alert, Button, Col, Row, Space, Typography } from "antd";
+import dayjs from "dayjs";
 import {
   ChangeEvent,
   Dispatch,
@@ -6,16 +9,13 @@ import {
   useRef,
   useState,
 } from "react";
-import { Alert, Button, Col, Row, Space, Typography } from "antd";
-import { SaveOutlined, CloseSquareFilled } from "@ant-design/icons";
-import "./DataEntryAggregateDataEntryForm.css";
-import dayjs from "dayjs";
-import { useHistory } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { GetRecord } from "../../graphql/__generated__/GetRecord";
-import { formMessageHandler } from "./DataEntryMessageHandler";
+import { useHistory } from "react-router-dom";
 import { GetDataset } from "../../graphql/__generated__/GetDataset";
+import { GetRecord } from "../../graphql/__generated__/GetRecord";
+import "./DataEntryAggregateDataEntryForm.css";
 import { DataEntryCategorySections } from "./DataEntryCategorySections";
+import { formMessageHandler } from "./DataEntryMessageHandler";
 import { useCreateRecordMutation, useUpdateRecordMutation } from "./hooks";
 
 const { Text } = Typography;

--- a/client/src/pages/DataEntry/DataEntryCategorySections.tsx
+++ b/client/src/pages/DataEntry/DataEntryCategorySections.tsx
@@ -1,8 +1,8 @@
 import { Card, Col, Row } from "antd";
+import _ from "lodash";
 import { ChangeEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { Entry } from "./DataEntryAggregateDataEntryForm";
-import _ from "lodash";
 
 interface DataEntryCategorySectionProps {
   entries: Entry[];

--- a/client/src/pages/DataEntry/DataEntryCategorySections.tsx
+++ b/client/src/pages/DataEntry/DataEntryCategorySections.tsx
@@ -1,5 +1,5 @@
 import { Card, Col, Row } from "antd";
-import React, { ChangeEvent } from "react";
+import { ChangeEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { Entry } from "./DataEntryAggregateDataEntryForm";
 import _ from "lodash";

--- a/client/src/pages/DataEntry/DataEntryPersonTypesInput.tsx
+++ b/client/src/pages/DataEntry/DataEntryPersonTypesInput.tsx
@@ -1,7 +1,6 @@
 import { Radio, Typography } from "antd";
-import React from "react";
 
-const { Text, Title } = Typography;
+const { Text } = Typography;
 
 // TODO: Replace with data for person types from query for dataset
 const personTypeOptions = [

--- a/client/src/pages/DataEntry/hooks.ts
+++ b/client/src/pages/DataEntry/hooks.ts
@@ -1,10 +1,4 @@
-import {
-  FetchResult,
-  MutationFunction,
-  MutationFunctionOptions,
-  MutationResult,
-  useMutation,
-} from "@apollo/client";
+import { MutationFunction, MutationResult, useMutation } from "@apollo/client";
 import { GetRecord } from "../../graphql/__generated__/GetRecord";
 import { UpdateRecord } from "../../graphql/__generated__/UpdateRecord";
 import { CREATE_RECORD } from "../../graphql/__mutations__/CreateRecord";

--- a/client/src/pages/DatasetDetails/DatasetDetails.tsx
+++ b/client/src/pages/DatasetDetails/DatasetDetails.tsx
@@ -1,5 +1,4 @@
 import { Button, PageHeader, Typography } from "antd";
-import React from "react";
 import { useHistory, useParams } from "react-router-dom";
 import { PlusOutlined } from "@ant-design/icons";
 import { DatasetDetailsRecordsTable } from "./DatasetDetailsRecordsTable";

--- a/client/src/pages/DatasetDetails/DatasetDetails.tsx
+++ b/client/src/pages/DatasetDetails/DatasetDetails.tsx
@@ -1,14 +1,14 @@
-import { Button, PageHeader, Typography } from "antd";
-import { useHistory, useParams } from "react-router-dom";
 import { PlusOutlined } from "@ant-design/icons";
-import { DatasetDetailsRecordsTable } from "./DatasetDetailsRecordsTable";
+import { useQuery } from "@apollo/client";
+import { Button, PageHeader, Typography } from "antd";
+import { useTranslation } from "react-i18next";
+import { useHistory, useParams } from "react-router-dom";
 import {
   GetDataset,
   GetDatasetVariables,
 } from "../../graphql/__generated__/GetDataset";
 import { GET_DATASET } from "../../graphql/__queries__/GetDataset.gql";
-import { useQuery } from "@apollo/client";
-import { useTranslation } from "react-i18next";
+import { DatasetDetailsRecordsTable } from "./DatasetDetailsRecordsTable";
 import { DatasetDetailsScoreCard } from "./DatasetDetailsScoreCard";
 
 interface RouteParams {

--- a/client/src/pages/DatasetDetails/DatasetDetailsRecordsTable.tsx
+++ b/client/src/pages/DatasetDetails/DatasetDetailsRecordsTable.tsx
@@ -1,20 +1,20 @@
-import { Button, Popconfirm, Space, Table } from "antd";
-import "./DatasetDetailsRecordsTable.css";
-import {
-  GetDataset,
-  GetDataset_dataset_records,
-} from "../../graphql/__generated__/GetDataset";
-import { GET_DATASET } from "../../graphql/__queries__/GetDataset.gql";
-import { DELETE_RECORD } from "../../graphql/__mutations__/DeleteRecord.gql";
-import { useTranslation } from "react-i18next";
 import { useMutation } from "@apollo/client";
+import { Button, Popconfirm, Space, Table } from "antd";
+import dayjs from "dayjs";
+import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
 import {
   messageError,
   messageInfo,
   messageSuccess,
 } from "../../components/Message";
-import dayjs from "dayjs";
+import {
+  GetDataset,
+  GetDataset_dataset_records,
+} from "../../graphql/__generated__/GetDataset";
+import { DELETE_RECORD } from "../../graphql/__mutations__/DeleteRecord.gql";
+import { GET_DATASET } from "../../graphql/__queries__/GetDataset.gql";
+import "./DatasetDetailsRecordsTable.css";
 
 interface DatasetRecordsTableProps {
   datasetId: string;

--- a/client/src/pages/DatasetDetails/DatasetDetailsRecordsTable.tsx
+++ b/client/src/pages/DatasetDetails/DatasetDetailsRecordsTable.tsx
@@ -1,5 +1,4 @@
 import { Button, Popconfirm, Space, Table } from "antd";
-import React from "react";
 import "./DatasetDetailsRecordsTable.css";
 import {
   GetDataset,
@@ -55,23 +54,23 @@ const DatasetDetailsRecordsTable = ({
     }, {});
   }) as TableData[];
 
-  const [
-    deleteRecord,
-    { loading: deleteRecordLoader, error: deleteRecordError },
-  ] = useMutation(DELETE_RECORD, {
-    onError: (error) => {
-      messageError(`${error.message}. Please try again later.`);
-    },
-    onCompleted: (deleted) => {
-      if (deleted) messageSuccess("Succesfully deleted record!");
-    }, // TODO: update cache instead of refetching
-    refetchQueries: [
-      {
-        query: GET_DATASET,
-        variables: { id: datasetId },
+  const [deleteRecord, { loading: deleteRecordLoader }] = useMutation(
+    DELETE_RECORD,
+    {
+      onError: (error) => {
+        messageError(`${error.message}. Please try again later.`);
       },
-    ],
-  });
+      onCompleted: (deleted) => {
+        if (deleted) messageSuccess("Succesfully deleted record!");
+      }, // TODO: update cache instead of refetching
+      refetchQueries: [
+        {
+          query: GET_DATASET,
+          variables: { id: datasetId },
+        },
+      ],
+    }
+  );
 
   const confirmDelete = (recordId: string) => {
     deleteRecord({ variables: { id: recordId } });
@@ -91,7 +90,7 @@ const DatasetDetailsRecordsTable = ({
       sticky
       title={() => t("datasetRecordsTableTitle", { title: "Records" })}
       pagination={{ hideOnSinglePage: true }}
-      loading={isLoading}
+      loading={isLoading || deleteRecordLoader}
       rowKey={(record) => record.id}
     >
       <Table.Column<TableData>

--- a/client/src/pages/DatasetDetails/DatasetDetailsScoreCard.tsx
+++ b/client/src/pages/DatasetDetails/DatasetDetailsScoreCard.tsx
@@ -1,11 +1,11 @@
+import { Pie } from "@ant-design/charts";
+import { PieConfig } from "@ant-design/charts/es/pie";
+import { Card, Col, Row } from "antd";
 import _ from "lodash";
 import {
   GetDataset,
   GetDataset_dataset_sumOfCategoryValueCounts_categoryValue,
 } from "../../graphql/__generated__/GetDataset";
-import { Pie } from "@ant-design/charts";
-import { PieConfig } from "@ant-design/charts/es/pie";
-import { Card, Col, Row } from "antd";
 import "./DatasetDetailsScoreCard.css";
 
 interface ScoreCardProps {

--- a/client/src/pages/DatasetDetails/DatasetDetailsScoreCard.tsx
+++ b/client/src/pages/DatasetDetails/DatasetDetailsScoreCard.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import _ from "lodash";
 import {
   GetDataset,

--- a/client/src/pages/Home/Home.tsx
+++ b/client/src/pages/Home/Home.tsx
@@ -1,18 +1,18 @@
-import { useState } from "react";
-import { Tag, Button, Table, Space } from "antd";
-import { HomeSearchAutoComplete } from "./HomeSearchAutoComplete";
-import { PlusOutlined, InfoCircleOutlined } from "@ant-design/icons";
-import { Link } from "react-router-dom";
-import { GetUser, GetUserVariables } from "../../graphql/__generated__/getUser";
-import { GET_USER } from "../../graphql/__queries__/GetUser.gql";
+import { InfoCircleOutlined, PlusOutlined } from "@ant-design/icons";
 import { useQuery } from "@apollo/client";
+import { Button, Space, Table, Tag } from "antd";
+import { ColumnsType } from "antd/lib/table";
 import dayjs from "dayjs";
 import localizedFormat from "dayjs/plugin/localizedFormat";
+import { useState } from "react";
 import { TFunction, useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
 import { useAuth } from "../../components/AuthProvider";
 import { ErrorFallback } from "../../components/Error/ErrorFallback";
 import { Loading } from "../../components/Loading/Loading";
-import { ColumnsType } from "antd/lib/table";
+import { GetUser, GetUserVariables } from "../../graphql/__generated__/getUser";
+import { GET_USER } from "../../graphql/__queries__/GetUser.gql";
+import { HomeSearchAutoComplete } from "./HomeSearchAutoComplete";
 
 dayjs.extend(localizedFormat);
 

--- a/client/src/pages/Home/Home.tsx
+++ b/client/src/pages/Home/Home.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { Tag, Button, Table, Space } from "antd";
 import { HomeSearchAutoComplete } from "./HomeSearchAutoComplete";
 import { PlusOutlined, InfoCircleOutlined } from "@ant-design/icons";

--- a/client/src/pages/Home/HomeDatasetsListTable.tsx
+++ b/client/src/pages/Home/HomeDatasetsListTable.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Table } from "antd";
 
 interface TableProps {

--- a/client/src/pages/Home/HomeSearchAutoComplete.tsx
+++ b/client/src/pages/Home/HomeSearchAutoComplete.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { AutoComplete, Input } from "antd";
 import { useTranslation } from "react-i18next";
 import "./HomeSearchAutoComplete.css";

--- a/client/src/pages/Login/Login.tsx
+++ b/client/src/pages/Login/Login.tsx
@@ -1,8 +1,7 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button, Form, Card, Input, Typography, Modal, message } from "antd";
 import { RouteComponentProps } from "react-router-dom";
-import { Auth } from "../../services/auth";
 import { useAuth } from "../../components/AuthProvider";
 import { useUserAccountManager } from "../../components/UserAccountManagerProvider";
 import "./Login.css";
@@ -31,8 +30,7 @@ export type LoginProps = RouteComponentProps;
 export const Login = (props: LoginProps) => {
   const auth = useAuth();
   const account = useUserAccountManager();
-  const { t, i18n } = useTranslation();
-  const [loading, setLoading] = useState(false);
+  const { t } = useTranslation();
   const [error, setError] = useState<Error | null>(null);
   const [showForgotPassword, setShowForgotPassword] = useState(false);
   const [resettingPassword, setResettingPassword] = useState(false);

--- a/client/src/pages/Login/Login.tsx
+++ b/client/src/pages/Login/Login.tsx
@@ -1,6 +1,6 @@
+import { Button, Card, Form, Input, message, Modal, Typography } from "antd";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Button, Form, Card, Input, Typography, Modal, message } from "antd";
 import { RouteComponentProps } from "react-router-dom";
 import { useAuth } from "../../components/AuthProvider";
 import { useUserAccountManager } from "../../components/UserAccountManagerProvider";

--- a/client/src/pages/ResetAccountPassword/ResetAccountPassword.tsx
+++ b/client/src/pages/ResetAccountPassword/ResetAccountPassword.tsx
@@ -1,7 +1,7 @@
+import { Alert, Button, Card, Form, Input, message, PageHeader } from "antd";
 import { useState } from "react";
-import { useLocation, useHistory } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { PageHeader, Card, Form, Input, Alert, Button, message } from "antd";
+import { useHistory, useLocation } from "react-router-dom";
 import { useUserAccountManager } from "../../components/UserAccountManagerProvider";
 import "./ResetAccountPassword.css";
 

--- a/client/src/pages/ResetAccountPassword/ResetAccountPassword.tsx
+++ b/client/src/pages/ResetAccountPassword/ResetAccountPassword.tsx
@@ -1,8 +1,7 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useLocation, useHistory } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { PageHeader, Card, Form, Input, Alert, Button, message } from "antd";
-import { Loading } from "../../components/Loading/Loading";
 import { useUserAccountManager } from "../../components/UserAccountManagerProvider";
 import "./ResetAccountPassword.css";
 
@@ -90,7 +89,11 @@ export const ResetAccountPassword = () => {
             <br />
           </>
         )}
-        <Form onFinish={saveNewPassword}>
+        <Form
+          labelCol={{ span: 6 }}
+          wrapperCol={{ span: 14 }}
+          onFinish={saveNewPassword}
+        >
           <PageHeader
             title={t("account.resetPassword.title")}
             subTitle={t("account.resetPassword.subtitle")}
@@ -112,8 +115,41 @@ export const ResetAccountPassword = () => {
             />
           </Form.Item>
 
+          <Form.Item
+            label={t("account.resetPassword.retypePasswordLabel")}
+            rules={[
+              {
+                required: true,
+                message: t("account.resetPassword.missingPassword"),
+              },
+              ({ getFieldValue }) => ({
+                validator(_, value) {
+                  if (!value || getFieldValue("password") === value) {
+                    return Promise.resolve();
+                  } else {
+                    return Promise.reject(
+                      new Error(t("account.resetPassword.passwordsDoNotMatch"))
+                    );
+                  }
+                },
+              }),
+            ]}
+            name="confirmPassword"
+          >
+            <Input.Password
+              aria-required="true"
+              aria-label={t("account.resetPassword.retypePasswordLabel")}
+              disabled={!canSubmit}
+            />
+          </Form.Item>
+
           <Form.Item wrapperCol={{ offset: 8, span: 16 }}>
-            <Button htmlType="submit" type="primary" disabled={!canSubmit}>
+            <Button
+              loading={resetting}
+              htmlType="submit"
+              type="primary"
+              disabled={!canSubmit}
+            >
               {t("account.resetPassword.submit")}
             </Button>
           </Form.Item>

--- a/client/src/pages/VerifyAccount.tsx
+++ b/client/src/pages/VerifyAccount.tsx
@@ -1,7 +1,7 @@
-import { useState, useEffect } from "react";
-import { useLocation, useHistory } from "react-router-dom";
-import { useTranslation } from "react-i18next";
 import { Alert, Button, message } from "antd";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useHistory, useLocation } from "react-router-dom";
 import { Loading } from "../components/Loading/Loading";
 import { useUserAccountManager } from "../components/UserAccountManagerProvider";
 

--- a/client/src/pages/VerifyAccount.tsx
+++ b/client/src/pages/VerifyAccount.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { useLocation, useHistory } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { Alert, Button, message } from "antd";

--- a/client/src/router/Router.tsx
+++ b/client/src/router/Router.tsx
@@ -3,7 +3,6 @@ import { Route, Switch, RouteComponentProps, Redirect } from "react-router-dom";
 import BreadCrumb from "../components/Breadcrumb/Breadcrumbs";
 import { VerifyAccount } from "../pages/VerifyAccount";
 import { IRoute } from "./routes";
-import { Auth } from "../services/auth";
 import { useAuth } from "../components/AuthProvider";
 import { ErrorBoundary } from "../components/Error/ErrorBoundary";
 import { ResetAccountPassword } from "../pages/ResetAccountPassword/ResetAccountPassword";

--- a/client/src/router/Router.tsx
+++ b/client/src/router/Router.tsx
@@ -1,13 +1,13 @@
 import React from "react";
-import { Route, Switch, RouteComponentProps, Redirect } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { Redirect, Route, RouteComponentProps, Switch } from "react-router-dom";
+import { useAuth } from "../components/AuthProvider";
 import BreadCrumb from "../components/Breadcrumb/Breadcrumbs";
+import { ErrorBoundary } from "../components/Error/ErrorBoundary";
+import { LoginProps } from "../pages/Login/Login";
+import { ResetAccountPassword } from "../pages/ResetAccountPassword/ResetAccountPassword";
 import { VerifyAccount } from "../pages/VerifyAccount";
 import { IRoute } from "./routes";
-import { useAuth } from "../components/AuthProvider";
-import { ErrorBoundary } from "../components/Error/ErrorBoundary";
-import { ResetAccountPassword } from "../pages/ResetAccountPassword/ResetAccountPassword";
-import { LoginProps } from "../pages/Login/Login";
-import { useTranslation } from "react-i18next";
 
 /**
  * Flatten routes to render components for a subroute

--- a/client/src/router/routes.tsx
+++ b/client/src/router/routes.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Redirect, RouteComponentProps } from "react-router-dom";
 import { BreadcrumbsRoute } from "use-react-router-breadcrumbs";
 import { DataEntry } from "../pages/DataEntry/DataEntry";

--- a/client/src/router/routes.tsx
+++ b/client/src/router/routes.tsx
@@ -1,12 +1,12 @@
 import { Redirect, RouteComponentProps } from "react-router-dom";
 import { BreadcrumbsRoute } from "use-react-router-breadcrumbs";
+import { EditProgram } from "../pages/Admin/EditProgram";
+import { EditUser } from "../pages/Admin/EditUser";
+import { ProgramList } from "../pages/Admin/ProgramList";
+import { UserList } from "../pages/Admin/UserList";
 import { DataEntry } from "../pages/DataEntry/DataEntry";
 import { DatasetDetails } from "../pages/DatasetDetails/DatasetDetails";
 import { Home } from "../pages/Home/Home";
-import { UserList } from "../pages/Admin/UserList";
-import { EditUser } from "../pages/Admin/EditUser";
-import { ProgramList } from "../pages/Admin/ProgramList";
-import { EditProgram } from "../pages/Admin/EditProgram";
 
 interface SubRoute extends BreadcrumbsRoute {
   key?: string;

--- a/client/src/services/i18next-test.ts
+++ b/client/src/services/i18next-test.ts
@@ -1,7 +1,7 @@
 import i18nextTest from "i18next";
 import { initReactI18next } from "react-i18next";
-import translationEnglish from "../../public/locales/en/translation.json";
 import translationUKEnglish from "../../public/locales/en-gb/translation.json";
+import translationEnglish from "../../public/locales/en/translation.json";
 
 i18nextTest.use(initReactI18next).init({
   lng: "en",

--- a/client/src/services/i18next.ts
+++ b/client/src/services/i18next.ts
@@ -1,7 +1,7 @@
 import i18next from "i18next";
-import { initReactI18next } from "react-i18next";
-import HttpBackendApi from "i18next-http-backend";
 import LanguageDetector from "i18next-browser-languagedetector";
+import HttpBackendApi from "i18next-http-backend";
+import { initReactI18next } from "react-i18next";
 
 i18next
   // pass the i18n instance to react-i18next

--- a/client/src/setupTests.ts
+++ b/client/src/setupTests.ts
@@ -1,17 +1,17 @@
 import "@testing-library/jest-dom";
-import { configure } from "enzyme";
+import "@testing-library/jest-dom/extend-expect";
 // Replaced enzyme-adapter-react-16 with @wojtekmaj/enzyme-adapter-react-17
 // since there's no enzyme-adapter-react-17 yet.
 // See: https://github.com/enzymejs/enzyme/pull/2430
 import Adapter from "@wojtekmaj/enzyme-adapter-react-17";
-import "@testing-library/jest-dom/extend-expect";
+import { configure } from "enzyme";
 import { toHaveNoViolations } from "jest-axe";
+// Mock HTTP requests via the `fetchMock` global.
+import jestFetchMock from "jest-fetch-mock";
 import i18nextTest from "../src/services/i18next-test";
 
 i18nextTest.createInstance();
 
-// Mock HTTP requests via the `fetchMock` global.
-import jestFetchMock from "jest-fetch-mock";
 // Mocks are enabled to get global objects like Response. Note that it's
 // usually better to avoid the fetchMock global and use dependency injection!
 jestFetchMock.enableMocks();

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,11 +1,8 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "noUnusedLocals": true,
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -20,14 +17,8 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": [
-    "src",
-    "./setupTest.ts",
-    "gql-mock-server.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ],
+  "include": ["src", "./setupTest.ts", "gql-mock-server.ts"],
+  "exclude": ["node_modules"],
   "ts-node": {
     // these options are overrides used only by ts-node
     "compilerOptions": {

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -12447,6 +12447,11 @@ prepend-http@^1.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
 
+prettier-plugin-organize-imports@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-2.2.0.tgz#dcdd5222416a90bd819734f131fea4a22b1c613a"
+  integrity sha512-2WM3moc/cAPCCsSneYhaL4+mMws0Bypbxz+98wuRyaA7GMokhOECVkQCG7l2hcH+9/4d5NsgZs9yktfwDy4r7A==
+
 prettier@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.0.tgz#b6a5bf1284026ae640f17f7ff5658a7567fc0d18"


### PR DESCRIPTION
- Adds the "confirm your password" input box to the reset password form
- Cleans up unused imports / turns on the relevant linter and build rules to enforce this
- Adds a `prettier` plugin to sort imports automatically, and applies this to all files