### PR TITLE
Add unique constraint to teams and programs by team

### DIFF
--- a/api/database.py
+++ b/api/database.py
@@ -11,7 +11,19 @@ import uuid
 
 import click
 from datetime import datetime
-from sqlalchemy import create_engine, Table, Boolean, Column, Integer, Float, String, DateTime, Text, ForeignKey, UniqueConstraint
+from sqlalchemy import (
+        create_engine,
+        Table,
+        Boolean,
+        Column,
+        Integer,
+        Float,
+        String,
+        DateTime,
+        Text,
+        ForeignKey,
+        UniqueConstraint,
+        )
 from sqlalchemy.orm import relationship, sessionmaker, validates
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import create_engine, event
@@ -93,7 +105,7 @@ class Team(Base, PermissionsMixin):
     __tablename__ = 'team'
 
     id = Column(GUID, primary_key=True, default=uuid.uuid4)
-    name = Column(String(255), nullable=False)
+    name = Column(String(255), nullable=False, unique=True)
     users = relationship('User', secondary=user_teams, backref='Team')
     programs = relationship('Program')
     organization_id = Column(GUID, ForeignKey(
@@ -193,6 +205,9 @@ class Program(Base, PermissionsMixin):
     updated = Column(TIMESTAMP,
                      server_default=func.now(), onupdate=func.now())
     deleted = Column(TIMESTAMP)
+
+    # Programs have to have a unique name within their respective team.
+    UniqueConstraint('name', 'team_id')
 
     @classmethod
     def get_not_deleted(cls, session, id_):

--- a/api/database.py
+++ b/api/database.py
@@ -367,6 +367,9 @@ class Dataset(Base, PermissionsMixin):
     tags = relationship('Tag', secondary=dataset_tags,
                         back_populates='datasets')
 
+    # Datasets must be unique within a program to avoid ambiguity.
+    UniqueConstraint('name', 'program_id')
+
     created = Column(TIMESTAMP,
                      server_default=func.now(), nullable=False)
     updated = Column(TIMESTAMP,


### PR DESCRIPTION
This will help limit confusion in big organizations that might have many Teams that have similarly named programs. (This was suggested by the BBC. I expect the same problem would come up with datasets vs programs, so I've added a constraint for those as well.)