### PR TITLE
[ch319] Admin - manage tags on programs

### DIFF
--- a/api/mutations.py
+++ b/api/mutations.py
@@ -331,7 +331,9 @@ def resolve_create_program(obj, info, input):
     
     program = Program(**input)
     program.datasets = [session.merge(Dataset(**dataset)) for dataset in datasets]
-    program.tags = [session.merge(Tag(**tag)) for tag in tags]
+    for tag_dict in tags:
+        tag = Tag.get_or_create_tag(session, tag_dict)
+        program.tags.append(tag)
 
     for target_dict in targets:
         cv_dict = target_dict.pop('category_value')
@@ -392,12 +394,10 @@ def resolve_update_program(obj, info, input):
 
     if 'tags' in input:
         program.tags = []
+
         for tag_dict in input.pop('tags'):
-            if 'id' in tag_dict:
-                tag_dict['id'] = uuid.UUID(tag_dict['id'])
-            elif 'tag_type' not in tag_dict:
-                tag_dict['tag_type'] = 'custom'
-            program.tags.append(session.merge(Tag(**tag_dict)))
+            tag = Tag.get_or_create_tag(session, tag_dict)
+            program.tags.append(tag)
 
     for key, value in input.items():
         setattr(program, key, value)

--- a/api/queries.py
+++ b/api/queries.py
@@ -11,6 +11,7 @@ from database import (
         Role,
         Program,
         Organization,
+        Tag,
         )
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -142,6 +143,17 @@ def resolve_category_value(obj, info, id):
     session = info.context['dbsession']
     category_value = CategoryValue.get_not_deleted(session, id)
     return category_value
+
+
+@query.field("tags")
+def resolve_tags(obj, info):
+    '''GraphQL query to return all tags.
+
+    :returns: List of tag objects
+    '''
+    session = info.context['dbsession']
+    return session.query(Tag).filter(Tag.deleted == None).order_by(Tag.name.asc()).all()
+
 
 @query.field("team")
 def resolve_team(obj, info, id):

--- a/api/schema.graphql
+++ b/api/schema.graphql
@@ -299,6 +299,9 @@ type Query {
   categoryValue(id: ID!): CategoryValue!
     @needsPermission(permission: [LOGGED_IN])
 
+  # Retrieve all tags. Server-side search not currently supported.
+  tags: [Tag!]! @needsPermission(permission: [LOGGED_IN])
+
   # Retrieve a team.
   team(id: ID!): Team! @needsPermission(permission: [LOGGED_IN])
 

--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -171,6 +171,7 @@
         "deactivateSuccess": "Successfully deleted",
         "saveSuccess": "$t(submitUpdateSuccess)",
         "restoreSuccess": "Successfully restored",
+        "newTagPrompt": "Create a new tag",
         "form": {
           "name": "Name",
           "description": "Description",
@@ -179,6 +180,7 @@
           "restore": "Restore",
           "confirmDelete": "Do you really wish to delete this $t(program)?",
           "team": "Assigned team",
+          "tags": "Tags",
           "datasetName": "Dataset name",
           "datasetDescription": "Dataset description",
           "addCategoryPlaceholder": "Select a new category to track",

--- a/client/src/__tests__/AdminEditProgram.test.tsx
+++ b/client/src/__tests__/AdminEditProgram.test.tsx
@@ -9,6 +9,7 @@ import { ADMIN_UPDATE_PROGRAM } from "../graphql/__mutations__/AdminUpdateProgra
 import { ADMIN_GET_ALL_CATEGORIES } from "../graphql/__queries__/AdminGetAllCategories.gql";
 import { ADMIN_GET_ALL_TEAMS } from "../graphql/__queries__/AdminGetAllTeams.gql";
 import { ADMIN_GET_PROGRAM } from "../graphql/__queries__/AdminGetProgram.gql";
+import { GET_ALL_TAGS } from "../graphql/__queries__/GetAllTags.gql";
 import { EditProgram } from "../pages/Admin/EditProgram";
 import { tick } from "./utils";
 
@@ -103,6 +104,31 @@ const CATEGORIES = {
   },
 };
 
+const TAGS = {
+  data: {
+    tags: [
+      {
+        id: "7295229a-696f-431e-b682-65dc468be857",
+        name: "tag1",
+        tagType: "custom",
+        description: "First test tag",
+      },
+      {
+        id: "04facfdd-6cdf-4481-895d-f7116014607c",
+        name: "tag2",
+        tagType: "custom",
+        description: "Second test tag",
+      },
+      {
+        id: "ccccc3b4-b910-4f6e-8f3c-8201c9999999",
+        name: "Existing tag",
+        tagType: "custom",
+        description: "The one the program uses by default",
+      },
+    ],
+  },
+};
+
 const apolloMocks = [
   {
     request: {
@@ -120,6 +146,10 @@ const apolloMocks = [
   {
     request: { query: ADMIN_GET_ALL_CATEGORIES },
     result: CATEGORIES,
+  },
+  {
+    request: { query: GET_ALL_TAGS },
+    result: TAGS,
   },
 ];
 
@@ -185,6 +215,7 @@ it("can set new target values for existing targets", async () => {
                 description: "first dataset",
               },
             ],
+            tags: [{ id: "ccccc3b4-b910-4f6e-8f3c-8201c9999999" }],
             targets: [
               {
                 id: "00000004-b910-4f6e-8f3c-8201c9999999",
@@ -282,6 +313,7 @@ it("can remove tracked targets", async () => {
                 description: "first dataset",
               },
             ],
+            tags: [{ id: "ccccc3b4-b910-4f6e-8f3c-8201c9999999" }],
             targets: [
               {
                 id: "00000004-b910-4f6e-8f3c-8201c9999999",
@@ -371,6 +403,7 @@ it("can add new tracked targets", async () => {
                 description: "first dataset",
               },
             ],
+            tags: [{ id: "ccccc3b4-b910-4f6e-8f3c-8201c9999999" }],
             targets: [
               {
                 id: "00000004-b910-4f6e-8f3c-8201c9999999",
@@ -517,6 +550,7 @@ it("can add and remove tracked categories", async () => {
             name: "My Program",
             description: "whatever",
             teamId: "eeeeeee4-b910-4f6e-8f3c-8201c9999999",
+            tags: [{ id: "ccccc3b4-b910-4f6e-8f3c-8201c9999999" }],
             datasets: [
               {
                 id: "fffff3b4-b910-4f6e-8f3c-8201c9999999",
@@ -545,6 +579,7 @@ it("can add and remove tracked categories", async () => {
             name: "My Program",
             description: "whatever",
             teamId: "eeeeeee4-b910-4f6e-8f3c-8201c9999999",
+            tags: [{ id: "ccccc3b4-b910-4f6e-8f3c-8201c9999999" }],
             datasets: [
               {
                 id: "fffff3b4-b910-4f6e-8f3c-8201c9999999",
@@ -649,6 +684,7 @@ it("can edit a dataset", async () => {
                 description: "first dataset - edited",
               },
             ],
+            tags: [{ id: "ccccc3b4-b910-4f6e-8f3c-8201c9999999" }],
             targets: [
               {
                 id: "00000004-b910-4f6e-8f3c-8201c9999999",
@@ -737,6 +773,7 @@ it("can add and remove datasets", async () => {
             name: "My Program",
             description: "whatever",
             teamId: "eeeeeee4-b910-4f6e-8f3c-8201c9999999",
+            tags: [{ id: "ccccc3b4-b910-4f6e-8f3c-8201c9999999" }],
             datasets: [
               {
                 name: "DS2",
@@ -839,6 +876,7 @@ it("can edit basic info: name and description and team", async () => {
             name: "new name",
             description: "new description",
             teamId: "fffffff4-b910-4f6e-8f3c-8201c9999999",
+            tags: [{ id: "ccccc3b4-b910-4f6e-8f3c-8201c9999999" }],
             datasets: [
               {
                 id: "fffff3b4-b910-4f6e-8f3c-8201c9999999",
@@ -1019,4 +1057,218 @@ it("can deactivate and reactivate a program", async () => {
 
   expect(screen.queryByText(/Error/)).not.toBeInTheDocument();
   expect(screen.queryByText(/alreadyDeletedTitle/)).not.toBeInTheDocument();
+});
+
+it("lets user add custom and existing tags", async () => {
+  const mocks = [
+    ...apolloMocks,
+    {
+      request: {
+        query: ADMIN_UPDATE_PROGRAM,
+        variables: {
+          input: {
+            id: "df6413b4-b910-4f6e-8f3c-8201c9e65af3",
+            name: "My Program",
+            description: "whatever",
+            teamId: "eeeeeee4-b910-4f6e-8f3c-8201c9999999",
+            tags: [
+              { id: "ccccc3b4-b910-4f6e-8f3c-8201c9999999" },
+              { name: "newtag" },
+              { id: "04facfdd-6cdf-4481-895d-f7116014607c" },
+            ],
+            datasets: [
+              {
+                id: "fffff3b4-b910-4f6e-8f3c-8201c9999999",
+                name: "DS1",
+                description: "first dataset",
+              },
+            ],
+            targets: [
+              {
+                id: "00000004-b910-4f6e-8f3c-8201c9999999",
+                target: 0.33,
+                categoryValue: {
+                  id: "00000004-b910-4f6e-8f3c-8201c0000000",
+                  name: "g1",
+                  category: { id: "00000004-b910-4f6e-8f3c-8201c1111111" },
+                },
+              },
+              {
+                id: "00000004-b910-4f6e-8f3c-8201c9555555",
+                categoryValue: {
+                  id: "00000004-b910-4f6e-8f3c-8201c0000001",
+                  name: "g2",
+                  category: {
+                    id: "00000004-b910-4f6e-8f3c-8201c1111111",
+                  },
+                },
+                target: 0.34,
+              },
+              {
+                id: "00000004-b910-4f6e-8f3c-8201c9555556",
+                target: 0.33,
+                categoryValue: {
+                  id: "00000004-b910-4f6e-8f3c-8201c0000002",
+                  name: "g3",
+                  category: { id: "00000004-b910-4f6e-8f3c-8201c1111111" },
+                },
+              },
+            ],
+          },
+        },
+      },
+      result: {
+        data: {
+          updateProgram: {
+            id: "df6413b4-b910-4f6e-8f3c-8201c9e65af3",
+          },
+        },
+      },
+    },
+  ];
+
+  render(
+    <MockedProvider mocks={mocks}>
+      <MemoryRouter initialEntries={["/df6413b4-b910-4f6e-8f3c-8201c9e65af3"]}>
+        <Route path="/:programId">
+          <EditProgram />
+        </Route>
+      </MemoryRouter>
+    </MockedProvider>
+  );
+
+  await tick();
+
+  const tagBox = screen.getByRole("combobox", { name: /tag/ });
+  userEvent.type(tagBox, "newtag");
+
+  await tick();
+
+  fireEvent.keyDown(tagBox, {
+    key: "enter",
+    code: 13,
+    charCode: 13,
+    keyCode: 13,
+  });
+
+  await tick();
+
+  userEvent.type(tagBox, "tag2");
+
+  await tick();
+
+  fireEvent.keyDown(tagBox, {
+    key: "arrowdown",
+    code: 40,
+    charCode: 40,
+    keyCode: 40,
+  });
+
+  await tick();
+
+  fireEvent.keyDown(tagBox, {
+    key: "enter",
+    code: 13,
+    charCode: 13,
+    keyCode: 13,
+  });
+
+  await tick();
+
+  fireEvent.click(screen.getByRole("button", { name: /save/ }));
+
+  // form validation
+  await tick();
+
+  // network request
+  await tick();
+
+  expect(screen.queryByText(/saveError/)).not.toBeInTheDocument();
+});
+
+it("lets user remove tags", async () => {
+  const mocks = [
+    ...apolloMocks,
+    {
+      request: {
+        query: ADMIN_UPDATE_PROGRAM,
+        variables: {
+          input: {
+            id: "df6413b4-b910-4f6e-8f3c-8201c9e65af3",
+            name: "My Program",
+            description: "whatever",
+            teamId: "eeeeeee4-b910-4f6e-8f3c-8201c9999999",
+            tags: [],
+            datasets: [
+              {
+                id: "fffff3b4-b910-4f6e-8f3c-8201c9999999",
+                name: "DS1",
+                description: "first dataset",
+              },
+            ],
+            targets: [
+              {
+                id: "00000004-b910-4f6e-8f3c-8201c9999999",
+                target: 0.33,
+                categoryValue: {
+                  id: "00000004-b910-4f6e-8f3c-8201c0000000",
+                  name: "g1",
+                  category: { id: "00000004-b910-4f6e-8f3c-8201c1111111" },
+                },
+              },
+              {
+                id: "00000004-b910-4f6e-8f3c-8201c9555555",
+                categoryValue: {
+                  id: "00000004-b910-4f6e-8f3c-8201c0000001",
+                  name: "g2",
+                  category: {
+                    id: "00000004-b910-4f6e-8f3c-8201c1111111",
+                  },
+                },
+                target: 0.34,
+              },
+              {
+                id: "00000004-b910-4f6e-8f3c-8201c9555556",
+                target: 0.33,
+                categoryValue: {
+                  id: "00000004-b910-4f6e-8f3c-8201c0000002",
+                  name: "g3",
+                  category: { id: "00000004-b910-4f6e-8f3c-8201c1111111" },
+                },
+              },
+            ],
+          },
+        },
+      },
+      result: {
+        data: {
+          updateProgram: {
+            id: "df6413b4-b910-4f6e-8f3c-8201c9e65af3",
+          },
+        },
+      },
+    },
+  ];
+
+  render(
+    <MockedProvider mocks={mocks}>
+      <MemoryRouter initialEntries={["/df6413b4-b910-4f6e-8f3c-8201c9e65af3"]}>
+        <Route path="/:programId">
+          <EditProgram />
+        </Route>
+      </MemoryRouter>
+    </MockedProvider>
+  );
+
+  await tick();
+
+  fireEvent.click(document.querySelector(".ant-select-selection-item-remove")!);
+
+  // form validation
+  await tick();
+
+  // network request
+  await tick();
+
+  expect(screen.queryByText(/saveError/)).not.toBeInTheDocument();
 });

--- a/client/src/graphql/__generated__/GetAllTags.ts
+++ b/client/src/graphql/__generated__/GetAllTags.ts
@@ -1,0 +1,20 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: GetAllTags
+// ====================================================
+
+export interface GetAllTags_tags {
+  readonly __typename: "Tag";
+  readonly id: string;
+  readonly name: string;
+  readonly tagType: string;
+  readonly description: string | null;
+}
+
+export interface GetAllTags {
+  readonly tags: ReadonlyArray<GetAllTags_tags>;
+}

--- a/client/src/graphql/__queries__/GetAllTags.gql.ts
+++ b/client/src/graphql/__queries__/GetAllTags.gql.ts
@@ -1,0 +1,12 @@
+import { gql } from "@apollo/client";
+
+export const GET_ALL_TAGS = gql`
+  query GetAllTags {
+    tags {
+      id
+      name
+      tagType
+      description
+    }
+  }
+`;

--- a/client/src/pages/Admin/EditProgram.tsx
+++ b/client/src/pages/Admin/EditProgram.tsx
@@ -32,9 +32,11 @@ import {
   AdminGetProgramVariables,
   AdminGetProgram_program_targets,
 } from "../../graphql/__generated__/AdminGetProgram";
+import { GetAllTags } from "../../graphql/__generated__/GetAllTags";
 import { ADMIN_GET_ALL_CATEGORIES } from "../../graphql/__queries__/AdminGetAllCategories.gql";
 import { ADMIN_GET_ALL_TEAMS } from "../../graphql/__queries__/AdminGetAllTeams.gql";
 import { ADMIN_GET_PROGRAM } from "../../graphql/__queries__/AdminGetProgram.gql";
+import { GET_ALL_TAGS } from "../../graphql/__queries__/GetAllTags.gql";
 import {
   CategoryTarget,
   CategoryTargetSegment,
@@ -124,6 +126,11 @@ export const EditProgram = () => {
     }
   );
 
+  const tagsResponse = useQueryWithErrorHandling<GetAllTags>(
+    GET_ALL_TAGS,
+    "tags"
+  );
+
   if (
     teamsResponse.loading ||
     programResponse.loading ||
@@ -140,6 +147,10 @@ export const EditProgram = () => {
     name: programResponse.data!.program.name,
     description: programResponse.data!.program.description,
     teamId: programResponse.data!.program.team?.id,
+    tags: programResponse.data!.program.tags.map(({ id, name }) => ({
+      label: name,
+      value: id,
+    })),
     targets: getGroupedTargets(programResponse.data!.program.targets),
     datasets: programResponse.data!.program.datasets.slice(),
   };
@@ -252,6 +263,23 @@ export const EditProgram = () => {
             {teamsResponse.data!.teams.map((t) => (
               <Select.Option key={t.id} value={t.id}>
                 {t.name}
+              </Select.Option>
+            ))}
+          </Select>
+        </Form.Item>
+
+        <Form.Item label={t("admin.program.edit.form.tags")} name="tags">
+          <Select
+            mode="tags"
+            labelInValue
+            placeholder={t("admin.program.edit.newTagPrompt")}
+            filterOption={(input, option) =>
+              option?.children?.toLowerCase().indexOf(input.toLowerCase()) >= 0
+            }
+          >
+            {tagsResponse.data?.tags.map((tag) => (
+              <Select.Option key={tag.id} value={tag.id}>
+                {tag.name}
               </Select.Option>
             ))}
           </Select>

--- a/client/src/pages/Admin/programHooks.ts
+++ b/client/src/pages/Admin/programHooks.ts
@@ -29,12 +29,21 @@ export type DatasetFormValues = Readonly<{
 }>;
 
 /**
+ * Form values to represent a tag for a program.
+ */
+export type TagFormValues = Readonly<{
+  value: string;
+  label: string;
+}>;
+
+/**
  * Form values filled out by the UI for updating the program.
  */
 export type ProgramUpdateFormValues = Readonly<{
   name: string;
   description: string;
   teamId?: string;
+  tags: TagFormValues[];
   datasets: DatasetFormValues[];
   targets: CategoryTarget[];
 }>;
@@ -78,6 +87,17 @@ export type HandlerArgs<F extends HandlerFunction> = F extends (
 ) => Promise<any>
   ? U
   : never;
+
+/**
+ * Check if the tag is a new custom tag that needs to be created on the server.
+ *
+ * This checks that the value is a UUIDv4. Test taken from here:
+ * https://stackoverflow.com/a/38191104
+ */
+export const isCustomTag = (tag: TagFormValues) =>
+  !/^[0-9A-F]{8}-[0-9A-F]{4}-[4][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i.test(
+    tag.value
+  );
 
 /**
  * Higher-order hook factory for network operations.
@@ -175,6 +195,9 @@ export const useSave = getOpHook(
             name: input.name,
             description: input.description,
             teamId: input.teamId,
+            tags: input.tags.map((tag) =>
+              isCustomTag(tag) ? { name: tag.value } : { id: tag.value }
+            ),
             datasets: input.datasets.map((dataset) => ({
               id: dataset.id,
               name: dataset.name,


### PR DESCRIPTION
Implements UI for viewing, adding, and removing tags on a program.

 - If tags exist already they will be reused
 - Tag existence is determined by UUID _and_ name, to try to avoid ambiguity (having tags with the same name)
 - If tags don't exist, they are created on the fly when the program is saved
 - Tag input has an autocomplete to suggest existing tags

screens:
<img width="697" alt="image" src="https://user-images.githubusercontent.com/1069899/125855290-adcaa12b-e812-4947-8712-1cb49004f273.png">
