### PR TITLE
[ch332] Prompt user to change password on first login

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -6,6 +6,7 @@ import datetime
 from fastapi import FastAPI, Request, Depends, HTTPException, Response
 from fastapi_users.authentication import CookieAuthentication
 from fastapi_users import FastAPIUsers
+from fastapi_users.utils import generate_jwt
 from sqlalchemy.ext.declarative import DeclarativeMeta, declarative_base
 import dateutil.parser
 
@@ -108,6 +109,16 @@ app.include_router(
     prefix="/auth",
     tags=["auth"],
 )
+
+@app.get("/reset-my-password")
+def get_reset_password_token(user = Depends(fastapi_users.get_current_user)):
+    """Get a token to reset one's own password."""
+    token_data = {"user_id": str(user.id), "aud": "fastapi-users:reset"}
+    token = generate_jwt(data=token_data, secret=settings.secret, lifetime_seconds=120)
+    return {
+        "token": token,
+    }
+
 
 # HACK(jnu): There's a bug in FastAPI where the /users/delete route returns a
 # None value for a 204 response. FastAPI chooses the JSONResponse class if no

--- a/api/database.py
+++ b/api/database.py
@@ -131,6 +131,8 @@ class User(Base, SQLAlchemyBaseUserTable):
     last_name = Column(String(50), nullable=False)
     roles = relationship('Role', secondary=user_roles, backref='User')
     teams = relationship('Team', secondary=user_teams, backref='User')
+    last_login = Column(TIMESTAMP, nullable=True)
+    last_changed_password = Column(TIMESTAMP, nullable=True)
 
     created = Column(TIMESTAMP,
                      server_default=func.now(), nullable=False)

--- a/api/user.py
+++ b/api/user.py
@@ -143,9 +143,9 @@ class SQLAlchemyORMUserDatabase(BaseUserDatabase):
         # Only allow updates of certain columns
         for k in ['first_name', 'last_name', 'email', 'is_active', 'is_verified', 'hashed_password']:
             if k in d:
-                setattr(dbuser, k, d[k])
-                if k == 'hashed_password':
+                if k == 'hashed_password' and dbuser.hashed_password != d[k]:
                     dbuser.last_changed_password = func.now()
+                setattr(dbuser, k, d[k])
 
                 # Special handling for deletes, since we use the `deleted`
                 # column while the fastapi-users library uses is_active. We

--- a/client/src/__tests__/Login.test.tsx
+++ b/client/src/__tests__/Login.test.tsx
@@ -3,9 +3,105 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { createMemoryHistory } from "history";
 import { AuthProvider } from "../components/AuthProvider";
 import { UserAccountManagerProvider } from "../components/UserAccountManagerProvider";
-import { mockUserNotLoggedIn } from "../graphql/__mocks__/auth";
+import { mockUserLogIn, mockUserNotLoggedIn } from "../graphql/__mocks__/auth";
 import { Login } from "../pages/Login/Login";
 import { mockUserAccountClient, tick } from "./utils";
+
+it("redirects user to the main page when they login (not on their first time)", async () => {
+  const user = "tester@notrealemail.info";
+  const password = "password";
+  const { auth } = mockUserLogIn(user, password);
+  await auth.init();
+
+  const history = createMemoryHistory();
+
+  const location = {
+    state: {},
+    pathname: "",
+    search: "",
+    hash: "",
+  };
+  const match = {
+    params: {},
+    isExact: true,
+    path: "",
+    url: "",
+  };
+
+  render(
+    <AuthProvider auth={auth}>
+      <UserAccountManagerProvider value={mockUserAccountClient}>
+        <Login history={history} match={match} location={location} />
+      </UserAccountManagerProvider>
+    </AuthProvider>
+  );
+
+  await tick();
+
+  fireEvent.change(screen.getByRole("textbox", { name: /e-mail/ }), {
+    target: { value: user },
+  });
+  fireEvent.change(document.querySelector(`[aria-label="password"]`)!, {
+    target: { value: password },
+  });
+  await tick();
+
+  fireEvent.click(screen.getByRole("button", { name: /action/ }));
+
+  await tick();
+
+  expect(history.location.pathname).toEqual("/");
+  expect(history.location.search).toEqual("");
+});
+
+it("prompts user to reset their password on their first login", async () => {
+  const user = "tester@notrealemail.info";
+  const password = "password";
+  const { auth } = mockUserLogIn(user, password, true);
+  await auth.init();
+
+  const history = createMemoryHistory();
+
+  const location = {
+    state: {},
+    pathname: "",
+    search: "",
+    hash: "",
+  };
+  const match = {
+    params: {},
+    isExact: true,
+    path: "",
+    url: "",
+  };
+
+  render(
+    <AuthProvider auth={auth}>
+      <UserAccountManagerProvider value={mockUserAccountClient}>
+        <Login history={history} match={match} location={location} />
+      </UserAccountManagerProvider>
+    </AuthProvider>
+  );
+
+  await tick();
+
+  fireEvent.change(screen.getByRole("textbox", { name: /e-mail/ }), {
+    target: { value: user },
+  });
+  fireEvent.change(document.querySelector(`[aria-label="password"]`)!, {
+    target: { value: password },
+  });
+  await tick();
+
+  fireEvent.click(screen.getByRole("button", { name: /action/ }));
+
+  await tick();
+
+  expect(history.location.pathname).toEqual("/account/reset-password");
+  expect(history.location.search).toEqual(
+    "?email=tester%40notrealemail.info&token=resettoken"
+  );
+});
 
 it("allows user to reset their password with their email", async () => {
   const { auth } = mockUserNotLoggedIn();

--- a/client/src/__tests__/auth.test.tsx
+++ b/client/src/__tests__/auth.test.tsx
@@ -29,6 +29,17 @@ it("logs a user in and out correctly", async () => {
   expect(auth.isLoggedIn()).toBe(false);
 });
 
+it("returns a special error if user has never changed password", async () => {
+  const user = "tester@notrealemail.info";
+  const password = "password";
+  const { auth } = mockUserLogIn(user, password, true);
+  await auth.init();
+
+  expect(await auth.login(user, password)).toEqual("CHANGE_PASSWORD");
+  expect(auth.isLoggedIn()).toBe(true);
+  expect(auth.getFullName()).toEqual("Penelope Pomegranate");
+});
+
 it("reports an error if user is not authed", async () => {
   const user = "tester@notrealemail.info";
   const password = "password";

--- a/client/src/graphql/__mocks__/auth.ts
+++ b/client/src/graphql/__mocks__/auth.ts
@@ -15,6 +15,8 @@ const defaultUser: UserProfile = {
   first_name: "Penelope",
   last_name: "Pomegranate",
   email: "penelope@pomegran.ate",
+  last_login: "2021-03-05T10:10:10Z",
+  last_changed_password: "2021-03-05T10:10:10Z",
   is_active: true,
   is_verified: true,
   id: "cb1aa2f7-2b27-4649-ba0d-f5c1e60fbb92",

--- a/client/src/graphql/__mocks__/auth.ts
+++ b/client/src/graphql/__mocks__/auth.ts
@@ -67,7 +67,11 @@ const createAuthorizedProfileResponse = (user?: Partial<UserProfile>) =>
 /**
  * Simulate logging in with a correct username and password.
  */
-export const mockUserLogIn = (email: string, password: string) => {
+export const mockUserLogIn = (
+  email: string,
+  password: string,
+  firstTime = false
+) => {
   let loggedIn = false;
 
   const mock = jest.fn(
@@ -80,6 +84,10 @@ export const mockUserLogIn = (email: string, password: string) => {
           return new Response(
             JSON.stringify({
               ...defaultUser,
+              last_login: firstTime ? null : defaultUser.last_login,
+              last_changed_password: firstTime
+                ? null
+                : defaultUser.last_changed_password,
               email,
             }),
             {
@@ -89,6 +97,13 @@ export const mockUserLogIn = (email: string, password: string) => {
               status: 200,
             }
           );
+        case "/api/reset-my-password":
+          return new Response(JSON.stringify({ token: "resettoken" }), {
+            headers: new Headers({
+              "Content-Type": "application/json",
+            }),
+            status: 200,
+          });
         case "/api/auth/cookie/login":
           expect(props?.method).toEqual("POST");
           expect(props?.credentials).toEqual("same-origin");

--- a/client/src/pages/Login/Login.tsx
+++ b/client/src/pages/Login/Login.tsx
@@ -42,6 +42,22 @@ export const Login = (props: LoginProps) => {
 
     const error = await auth.login(email, password);
     if (error) {
+      // If the error tells us to reset the password, then redirect
+      if (error === "CHANGE_PASSWORD") {
+        const token = await auth.getResetToken();
+        const params = new URLSearchParams({
+          email,
+          token,
+        });
+
+        props.history.push({
+          pathname: "/account/reset-password",
+          search: `?${params.toString()}`,
+        });
+        return;
+      }
+
+      // Otherwise a bad error happened
       setError(new Error(error));
     } else {
       const state = props.location.state;

--- a/client/src/services/auth.ts
+++ b/client/src/services/auth.ts
@@ -14,6 +14,8 @@ export type UserProfile = Readonly<{
   email: string;
   is_active: boolean;
   is_verified: boolean;
+  last_changed_password: string | null;
+  last_login: string | null;
   first_name: string;
   last_name: string;
   roles: UserRole[];
@@ -187,12 +189,30 @@ export class Auth {
     });
 
     if (response.ok) {
-      return this.refreshCurrentUser();
+      await this.refreshCurrentUser();
+      if (!this.currentUser) {
+        return "UNKNOWN_ERROR";
+      }
+
+      if (!this.currentUser.last_changed_password) {
+        return "CHANGE_PASSWORD";
+      }
+
+      return;
     }
 
     const json = await response.json();
 
     return (json && json["detail"]) || "An unknown error occurred";
+  }
+
+  /**
+   * Get a password reset token
+   */
+  public async getResetToken() {
+    const resetResponse = await this.fetcher("/api/reset-my-password");
+    const resetJson = await resetResponse.json();
+    return resetJson["token"];
   }
 
   /**

--- a/client/src/services/auth.ts
+++ b/client/src/services/auth.ts
@@ -198,7 +198,7 @@ export class Auth {
         return "CHANGE_PASSWORD";
       }
 
-      return;
+      return null;
     }
 
     const json = await response.json();


### PR DESCRIPTION
 - Add `last_login` column to database and track this when user logs in
 - Add `last_changed_password` column to database and track this when user changes password
 - API route to get a password reset token for one's own account if they are logged in
 - Detect when user has never changed password and immediately prompt them to do so when they log in

Not a hugely important feature, but I wanted to get this PR in soon bc it adds database columns.