### PR TITLE
[Ch333] UI for bootstrapping on first app load

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -94,8 +94,10 @@ app.include_router(
 @app.get("/reset-my-password")
 def get_reset_password_token(dbuser = Depends(user.fastapi_users.get_current_user)):
     """Get a token to reset one's own password."""
-    token_data = {"user_id": str(dbuser.id)}
-    token = user.generate_token(data=token_data, type_=RESET_PASSWORD_TOKEN_AUDIENCE, lifetime_seconds=120)
+    token = user.get_valid_token(
+        RESET_PASSWORD_TOKEN_AUDIENCE,
+        user_id=str(dbuser.id),
+        )
     return {
         "token": token,
         }
@@ -122,8 +124,8 @@ delete_route.response_class = Response
 
 # Separately, to implement "blank slate" mode, use a dependency that returns
 # a 418 code when the app is not yet configured.
-async def blank_slate():
-    if is_blank_slate():
+async def blank_slate(request: Request):
+    if is_blank_slate(request.scope.get('dbsession')):
         raise HTTPException(status_code=418, detail="App is not yet configured")
 
 app.include_router(

--- a/api/app_test.py
+++ b/api/app_test.py
@@ -10,8 +10,8 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
-from app import schema, app, cookie_authentication
-from user import user_db
+from app import schema, app
+from user import user_db, cookie_authentication, get_valid_token
 from database import (
     Base,
     create_tables,
@@ -28,14 +28,6 @@ from database import (
 )
 from uuid import UUID
 
-
-def get_valid_token(aud, **kwargs):
-    data = {"aud": aud}
-    data.update(kwargs)
-    return generate_jwt(data,
-            cookie_authentication.lifetime_seconds,
-            cookie_authentication.secret,
-            JWT_ALGORITHM)
 
 
 class BaseAppTest(unittest.TestCase):
@@ -59,7 +51,7 @@ class BaseAppTest(unittest.TestCase):
         Session = sessionmaker(bind=self.engine)
         session = Session()
 
-        create_tables(self.engine, session)
+        create_tables(session)
         create_dummy_data(session)
 
         session.close()
@@ -689,18 +681,6 @@ class TestGraphQL(BaseAppTest):
                             "publicationDate": "2020-12-21T00:00:00",
                             "entries": [
                                 {
-                                    'id': '64677dc1-a1cd-4cd3-965d-6565832d307a',
-                                    'count': 1,
-                                    'inputter': {
-                                        'id': 'cd7e6d44-4b4d-4d7a-8a67-31efffe53e77',
-                                        'firstName': 'Cat'
-                                    },
-                                    "categoryValue": {
-                                        "id": "6cae6d26-97e1-4e9c-b1ad-954b4110e83b",
-                                        "name": "Non-binary"
-                                    }
-                                },
-                                {
                                     'id': 'a37a5fe2-1493-4cb9-bcd0-a87688ffa409',
                                     'count': 1,
                                     'inputter': {
@@ -757,6 +737,18 @@ class TestGraphQL(BaseAppTest):
                                     'categoryValue': {
                                         "id": "a72ced2b-b1a6-4d3d-b003-e35e980960df",
                                         "name": "Gender non-conforming"
+                                    }
+                                },
+                                {
+                                    'id': '64677dc1-a1cd-4cd3-965d-6565832d307a',
+                                    'count': 1,
+                                    'inputter': {
+                                        'id': 'cd7e6d44-4b4d-4d7a-8a67-31efffe53e77',
+                                        'firstName': 'Cat'
+                                    },
+                                    "categoryValue": {
+                                        "id": "6cae6d26-97e1-4e9c-b1ad-954b4110e83b",
+                                        "name": "Non-binary"
                                     }
                                 },
                                 {
@@ -1099,10 +1091,6 @@ class TestGraphQL(BaseAppTest):
                         "dataset": {"id": "b3e7d42d-2bb7-4e25-a4e1-b8d30f3f6e89"},
                         "entries": [
                             {"categoryValue": {
-                                "id": "6cae6d26-97e1-4e9c-b1ad-954b4110e83b",
-                                "name": "Non-binary"
-                            }},
-                            {"categoryValue": {
                                 "id": "742b5971-eeb6-4f7a-8275-6111f2342bb4",
                                 "name": "Cisgender women"
                             }},
@@ -1121,6 +1109,10 @@ class TestGraphQL(BaseAppTest):
                             {'categoryValue': {
                                 "id": "a72ced2b-b1a6-4d3d-b003-e35e980960df",
                                 "name": "Gender non-conforming"
+                            }},
+                            {"categoryValue": {
+                                "id": "6cae6d26-97e1-4e9c-b1ad-954b4110e83b",
+                                "name": "Non-binary"
                             }},
                             {"categoryValue": {
                                 "id": "c36958cb-cc62-479e-ab61-eb03896a981c",
@@ -1324,12 +1316,12 @@ class TestGraphQL(BaseAppTest):
                         "publicationDate": "2020-12-25T00:00:00",
                         "dataset": {"id": "96336531-9245-405f-bd28-5b4b12ea3798", "name": "12PM - 4PM"},
                         "entries": [
-                            {"count": 0, "categoryValue": {"id": "6cae6d26-97e1-4e9c-b1ad-954b4110e83b", "name": "Non-binary", "category": {"id": "51349e29-290e-4398-a401-5bf7d04af75e", "name": "Gender"}}},
                             {"count": 1, "categoryValue": {"id": "742b5971-eeb6-4f7a-8275-6111f2342bb4", "name": "Cisgender women", "category": {"id": "51349e29-290e-4398-a401-5bf7d04af75e", "name": "Gender"}}},
                             {"count": 1, "categoryValue": {"id": "d237a422-5858-459c-bd01-a0abdc077e5b", "name": "Cisgender men", "category": {"id": "51349e29-290e-4398-a401-5bf7d04af75e", "name": "Gender"}}},
                             {"count": 1, "categoryValue": {"id": "662557e5-aca8-4cec-ad72-119ad9cda81b", "name": "Trans women", "category": {"id": "51349e29-290e-4398-a401-5bf7d04af75e", "name": "Gender"}}},
                             {"count": 1, "categoryValue": {"id": "1525cce8-7db3-4e73-b5b0-d2bd14777534", "name": "Trans men", "category": {"id": "51349e29-290e-4398-a401-5bf7d04af75e", "name": "Gender"}}},
                             {"count": 1, "categoryValue": {"id": "a72ced2b-b1a6-4d3d-b003-e35e980960df", "name": "Gender non-conforming", "category": {"id": "51349e29-290e-4398-a401-5bf7d04af75e", "name": "Gender"}}},
+                            {"count": 0, "categoryValue": {"id": "6cae6d26-97e1-4e9c-b1ad-954b4110e83b", "name": "Non-binary", "category": {"id": "51349e29-290e-4398-a401-5bf7d04af75e", "name": "Gender"}}},
                             {"count": 1, "categoryValue": {"id": "c36958cb-cc62-479e-ab61-eb03896a981c", "name": "Disabled", "category": {"id": "55119215-71e9-43ca-b2c1-7e7fb8cec2fd", "name": "Disability"}}},
                             {"count": 1, "categoryValue": {"id": "55119215-71e9-43ca-b2c1-7e7fb8cec2fd", "name": "Non-disabled", "category": {"id": "55119215-71e9-43ca-b2c1-7e7fb8cec2fd", "name": "Disability"}}},
                         ]
@@ -2499,15 +2491,15 @@ class TestGraphQL(BaseAppTest):
                             "name": "An updated new Program",
                             "targets": [
                                 {
+                                    "categoryValue": {"name": "Non-binary"},
+                                    "target": 0.17,
+                                },
+                                {
                                     "categoryValue": {"name": "Cisgender men"},
                                     "target": 0.16,
                                 },
                                 {
                                     "categoryValue": {"name": "Trans women"},
-                                    "target": 0.17,
-                                },
-                                {
-                                    "categoryValue": {"name": "Non-binary"},
                                     "target": 0.17,
                                 },
                                 {

--- a/api/database.py
+++ b/api/database.py
@@ -613,10 +613,44 @@ def create_tables(session):
     engine = session.bind
     Base.metadata.create_all(engine)
 
+    # Default roles
     session.add(Role(
         id="be5f8cac-ac65-4f75-8052-8d1b5d40dffe",
         name="admin",
         description="User is an admin and has administrative privileges"))
+    
+    # Default demographic categories
+    session.add(Category(
+        id='51349e29-290e-4398-a401-5bf7d04af75e',
+        name='gender', 
+        description=(
+            'Gender: A social construct based on a group of emotional and '
+            'psychological characteristics that classify an individual as '
+            'feminine, masculine, androgynous or other. Gender can be '
+            'understood to have several components, including gender identity, '
+            'gender expression and gender role.'
+            )))
+    session.add(Category(
+        id='2f98f223-417f-41ea-8fdb-35f0c5fe5b41',
+        name='race / ethnicity',
+        description=(
+            'Race & Ethnicity: Social constructs that categorize groups of '
+            'people based on shared social and physical qualities. Definitions '
+            'of race and ethnicity are not universally agreed upon and vary '
+            'over time and place. Individuals may identify as belonging to '
+            'multiple racial and ethnic groups.'
+            )))
+    session.add(Category(
+        id='55119215-71e9-43ca-b2c1-7e7fb8cec2fd',
+        name='disability',
+        description=(
+            'A disability is any condition of the body or mind (impairment) '
+            'that makes it more difficult for the person with the condition '
+            'to do certain activities (activity limitation) and interact with '
+            'the world around them (participation restrictions). Some '
+            'disabilities may be hidden or not easy to see.'
+            )))
+
     session.commit()
 
 
@@ -670,10 +704,9 @@ def create_dummy_data(session):
     Tag(id='4a2142c0-5416-431d-b62f-0dbfe7574688', name='news', description='tag for all news programming',
             tag_type='news', programs=[program], datasets=[ds1, ds2])
     
-    category_gender = Category(id='51349e29-290e-4398-a401-5bf7d04af75e', name='gender', 
-                               description='Gender: A social construct based on a group of emotional and psychological characteristics that classify an individual as feminine, masculine, androgynous or other. Gender can be understood to have several components, including gender identity, gender expression and gender role.')
-    category_race = Category(id='2f98f223-417f-41ea-8fdb-35f0c5fe5b41', name='race', description='Race: is ...')
-    category_disability = Category(id='55119215-71e9-43ca-b2c1-7e7fb8cec2fd', name='disability', description='A disability is any condition of the body or mind (impairment) that makes it more difficult for the person with the condition to do certain activities (activity limitation) and interact with the world around them (participation restrictions). Some disabilities may be hidden or not easy to see.')
+    category_gender = session.query(Category).get('51349e29-290e-4398-a401-5bf7d04af75e')
+    category_disability = session.query(Category).get('55119215-71e9-43ca-b2c1-7e7fb8cec2fd')
+    category_race = session.query(Category).get('2f98f223-417f-41ea-8fdb-35f0c5fe5b41')
     
     target_non_binary = Target(id='40eaeafc-3311-4294-a639-a826eb6495ab', program=program, target_date=datetime.strptime('2022-12-31 00:00:00', '%Y-%m-%d %H:%M:%S'), target=float(.17))
     target_cis_women = Target(id='eccf90e8-3261-46c1-acd5-507f9113ff72', program=program, target_date=datetime.strptime('2022-12-31 00:00:00', '%Y-%m-%d %H:%M:%S'), target=float(.17))

--- a/api/database.py
+++ b/api/database.py
@@ -94,7 +94,7 @@ connection = Proxy(init_db)
 
 
 _blank_slate = True
-def is_blank_slate():
+def is_blank_slate(session):
     """Check if the app has been initialized at all.
 
     If the app has been initialized, this returns False and future lookups are
@@ -106,9 +106,7 @@ def is_blank_slate():
     if not _blank_slate:
         return False
 
-    session = connection()
     org_count = session.query(Organization).count()
-    session.close()
 
     if org_count > 0:
         _blank_slate = False

--- a/api/database.py
+++ b/api/database.py
@@ -115,6 +115,12 @@ def is_blank_slate(session):
     return True
 
 
+def clear_cached_state():
+    """Reset cached state. (Useful for testing.)"""
+    global _blank_slate
+    _blank_slate = True
+
+
 
 Base = declarative_base()
 

--- a/api/directives.py
+++ b/api/directives.py
@@ -5,6 +5,7 @@ from graphql.type import (
         GraphQLObjectType,
         )
 from database import (
+        is_blank_slate,
         PermissionsMixin,
         User,
         Dataset,
@@ -43,6 +44,11 @@ def user_has_permission(permissions: Iterable[str], obj, info) -> bool:
     current_user = info.context.get('current_user')
     if 'LOGGED_IN' in permissions:
         if current_user:
+            return True
+
+    if 'BLANK_SLATE' in permissions:
+        # Any user has this permission if the app has not been configured yet.
+        if is_blank_slate():
             return True
 
     # The rest of the permissions assume LOGGED_IN is true, since they

--- a/api/directives.py
+++ b/api/directives.py
@@ -48,7 +48,7 @@ def user_has_permission(permissions: Iterable[str], obj, info) -> bool:
 
     if 'BLANK_SLATE' in permissions:
         # Any user has this permission if the app has not been configured yet.
-        if is_blank_slate():
+        if is_blank_slate(info.context['dbsession']):
             return True
 
     # The rest of the permissions assume LOGGED_IN is true, since they

--- a/api/mutations.py
+++ b/api/mutations.py
@@ -2,7 +2,7 @@ import uuid
 import secrets
 
 import mailer
-from user import fastapi_users, UserCreateModel, UserRole, generate_token
+from user import fastapi_users, UserCreateModel, UserRole, get_valid_token
 from ariadne import convert_kwargs_to_snake_case, ObjectType
 from settings import settings
 from database import (
@@ -485,13 +485,11 @@ async def resolve_configure_app(obj, info, input):
     # TODO: Unify the email to streamline this process
     # https://app.clubhouse.io/stanford-computational-policy-lab/story/334/unify-registration-emails
     await mailer.send_register_email(user, temp_password)
-    token = generate_token(
-            data={
-                'user_id': str(user.id),
-                'email': user.email,
-                },
-            type_=VERIFY_USER_TOKEN_AUDIENCE,
-            )
+    token = get_valid_token(
+                VERIFY_USER_TOKEN_AUDIENCE,
+                user_id=str(user.id),
+                email=user.email,
+                )
     await mailer.send_verify_request_email(user, token)
 
     session.commit()

--- a/api/mutations.py
+++ b/api/mutations.py
@@ -2,7 +2,7 @@ import uuid
 
 from ariadne import convert_kwargs_to_snake_case, ObjectType
 from settings import settings
-from database import SessionLocal, User, Dataset, Tag, Program, Record, Entry, Category, Target, CategoryValue, Team
+from database import User, Dataset, Tag, Program, Record, Entry, Category, Target, CategoryValue, Team
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.sql import func

--- a/api/mutations.py
+++ b/api/mutations.py
@@ -1,11 +1,29 @@
 import uuid
+import secrets
 
+import mailer
+from user import fastapi_users, UserCreateModel, UserRole, generate_token
 from ariadne import convert_kwargs_to_snake_case, ObjectType
 from settings import settings
-from database import User, Dataset, Tag, Program, Record, Entry, Category, Target, CategoryValue, Team
+from database import (
+        Category,
+        CategoryValue,
+        Dataset,
+        Entry,
+        Organization,
+        Program,
+        Record,
+        Role,
+        Tag,
+        User,
+        Target,
+        Team,
+        )
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.sql import func
+from fastapi_users.router.verify import VERIFY_USER_TOKEN_AUDIENCE
+
 
 mutation = ObjectType("Mutation")
 
@@ -432,3 +450,50 @@ def resolve_restore_program(obj, info, id):
     session.commit()
 
     return program
+
+
+@mutation.field("configureApp")
+@convert_kwargs_to_snake_case
+async def resolve_configure_app(obj, info, input):
+    """GraphQL mutation to configure the app when it's first opened.
+
+    :param input: Config parameters
+    :returns: User object of the new admin
+    """
+    session = info.context['dbsession']
+    org = Organization(name=input.pop('organization'))
+    session.add(org)
+
+    # Create a good temporary password
+    temp_password = password=secrets.token_urlsafe(16)
+    # Get a list of roles to grant this person
+    super_roles = session.query(Role).filter(Role.name == 'admin').all()
+    # Create the new user
+    new_user = UserCreateModel(
+            email=input['email'],
+            first_name=input['first_name'],
+            last_name=input['last_name'],
+            password=temp_password,
+            is_superuser=True,
+            roles=[UserRole(id=role.id) for role in super_roles],
+            teams=[],
+            )
+
+    user = await fastapi_users.create_user(new_user)
+
+    # Send temp password.
+    # TODO: Unify the email to streamline this process
+    # https://app.clubhouse.io/stanford-computational-policy-lab/story/334/unify-registration-emails
+    await mailer.send_register_email(user, temp_password)
+    token = generate_token(
+            data={
+                'user_id': str(user.id),
+                'email': user.email,
+                },
+            type_=VERIFY_USER_TOKEN_AUDIENCE,
+            )
+    await mailer.send_verify_request_email(user, token)
+
+    session.commit()
+
+    return user.id

--- a/api/mutations.py
+++ b/api/mutations.py
@@ -463,6 +463,7 @@ async def resolve_configure_app(obj, info, input):
     session = info.context['dbsession']
     org = Organization(name=input.pop('organization'))
     session.add(org)
+    session.commit()
 
     # Create a good temporary password
     temp_password = password=secrets.token_urlsafe(16)
@@ -491,7 +492,5 @@ async def resolve_configure_app(obj, info, input):
                 email=user.email,
                 )
     await mailer.send_verify_request_email(user, token)
-
-    session.commit()
 
     return user.id

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -23,6 +23,7 @@ iniconfig==1.1.1
 install==1.3.4
 itsdangerous==1.1.0
 Jinja2==2.11.2
+lazy-object-proxy==1.6.0
 makefun==1.9.5
 MarkupSafe==1.1.1
 packaging==20.9

--- a/api/schema.graphql
+++ b/api/schema.graphql
@@ -26,6 +26,9 @@ enum Permission {
   # belongs to the team that owns the object in question (e.g., they are on
   # the team that owns the Program they are querying).
   TEAM_MEMBER
+  # When the app has not been configured yet, it is in the blank slate mode
+  # that allows any visitor to configure it.
+  BLANK_SLATE
 }
 
 schema {
@@ -275,6 +278,13 @@ input UpdateProgramInput {
   datasets: [UpsertDatasetInput!]
 }
 
+input FirstTimeAppConfigurationInput {
+  organization: String!
+  email: String!
+  firstName: String!
+  lastName: String!
+}
+
 type Query {
   # NOTE: Permissions are enforced at the object-level as objects are returned.
 
@@ -391,4 +401,8 @@ type Mutation {
 
   # Restore a Program
   restoreProgram(id: ID!): Program! @needsPermission(permission: [ADMIN])
+
+  # First-time app configuration
+  configureApp(input: FirstTimeAppConfigurationInput!): ID!
+    @needsPermission(permission: [BLANK_SLATE])
 }

--- a/api/user.py
+++ b/api/user.py
@@ -196,4 +196,5 @@ class SQLAlchemyORMUserDatabase(BaseUserDatabase):
 
         return user
 
-user_db = SQLAlchemyORMUserDatabase(database.SessionLocal)
+
+user_db = SQLAlchemyORMUserDatabase(database.connection)

--- a/api/user.py
+++ b/api/user.py
@@ -1,10 +1,14 @@
 from pydantic import BaseModel, UUID4, EmailStr
 from datetime import datetime
+from fastapi_users.authentication import CookieAuthentication
+from fastapi_users import FastAPIUsers
 from fastapi_users import models
+from fastapi_users.utils import generate_jwt
 from fastapi_users.db.base import BaseUserDatabase
 from fastapi_users.db.sqlalchemy import GUID
 from sqlalchemy.sql import func
-from typing import Optional, List
+from typing import Optional, List, Dict
+from settings import settings
 import database
 
 
@@ -62,6 +66,8 @@ class UserCreateModel(BaseUserCreateUpdate):
     password: str
     first_name: str
     last_name: str
+    roles: Optional[List[UserRole]]
+    teams: Optional[List[UserTeam]]
 
 
 class UserUpdateModel(BaseUserCreateUpdate):
@@ -121,11 +127,17 @@ class SQLAlchemyORMUserDatabase(BaseUserDatabase):
         # TODO! Use an async session
         session = self.session_factory()
         d = user.dict()
-        if not d['roles']:
-            d['roles'] = []
-        if not d['teams']:
-            d['teams'] = []
+        roles = d.pop('roles', [])
+        teams = d.pop('teams', [])
         dbuser = database.User(**d)
+        if roles:
+            dbuser.roles = session.query(database.Role).filter(
+                    database.Role.id.in_([r['id'] for r in roles])
+                    ).all()
+        if teams:
+            dbuser.teams = session.query(database.Team).filter(
+                    database.Team.id.in_([t['id'] for t in teams])
+                    ).all()
         session.add(dbuser)
         session.commit()
         user = self.format_orm_model(dbuser)
@@ -198,3 +210,36 @@ class SQLAlchemyORMUserDatabase(BaseUserDatabase):
 
 
 user_db = SQLAlchemyORMUserDatabase(database.connection)
+
+
+# remove cookie_secure=False later for production
+cookie_authentication = CookieAuthentication(
+        secret=settings.secret,
+        lifetime_seconds=3600,
+        cookie_secure=False,
+        cookie_name='rtauth')
+
+
+fastapi_users = FastAPIUsers(
+    user_db,
+    [cookie_authentication],
+    UserModel,
+    UserCreateModel,
+    UserUpdateModel,
+    UserDBModel,
+)
+
+
+def generate_token(data: Dict, type_: str, lifetime_seconds: int = 3600) -> str:
+    """Get a valid JWT for fastapi-users.
+
+    :param data: Data to encode in the token
+    :param type_: Audience constant (see fastapi-users for details)
+    :param lifetime_seconds: Token lifetime
+    :returns: Encoded JWT
+    """
+    token_data = {
+            'aud': type_,
+            }
+    token_data.update(data)
+    return generate_jwt(data=token_data, secret=settings.secret, lifetime_seconds=lifetime_seconds)

--- a/api/user.py
+++ b/api/user.py
@@ -230,16 +230,16 @@ fastapi_users = FastAPIUsers(
 )
 
 
-def generate_token(data: Dict, type_: str, lifetime_seconds: int = 3600) -> str:
+def get_valid_token(type_: str, **kwargs) -> str:
     """Get a valid JWT for fastapi-users.
 
-    :param data: Data to encode in the token
-    :param type_: Audience constant (see fastapi-users for details)
-    :param lifetime_seconds: Token lifetime
+    :param type_: Token audience (see fastapi-users for constants)
+    :param **kwargs: Data to encode in the token
     :returns: Encoded JWT
     """
-    token_data = {
-            'aud': type_,
-            }
-    token_data.update(data)
-    return generate_jwt(data=token_data, secret=settings.secret, lifetime_seconds=lifetime_seconds)
+    token_data = {'aud': type_}
+    token_data.update(kwargs)
+    return generate_jwt(
+            data=token_data,
+            secret=cookie_authentication.secret,
+            lifetime_seconds=cookie_authentication.lifetime_seconds)

--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -21,6 +21,30 @@
   "submitUpdateFail": "Failed to save changes.",
   "cancel": "Cancel",
   "confirmLeavePage": "Your changes have not been saved, are you sure you want to leave this page?",
+  "placeholder": {
+    "email": "tina@turner.org",
+    "organization": "Tina Turner Foundation",
+    "firstName": "Tina",
+    "lastName": "Turner"
+  },
+  "app": {
+    "configure": {
+      "title": "App configuration",
+      "description": "Hello! You are the very first person to use this app since it was set up. Please tell us who you are. We will create an admin user account for you. We will email you a temporary password which you can use to login and continue setting up the tool.",
+      "organization": "Name of your organization",
+      "organizationRequired": "You must enter an organization name.",
+      "firstName": "Your first name",
+      "firstNameRequired": "You must enter your first name.",
+      "lastName": "Your last name",
+      "lastNameRequired": "You must enter your last name.",
+      "email": "Your email address",
+      "emailRequired": "You must enter your email.",
+      "emailFormat": "You must enter a valid email address.",
+      "submit": "Configure the app!",
+      "success": "Success! Check your email for a temporary password you can use to log in.",
+      "error": "Uh-oh, that didn't work."
+    }
+  },
   "account": {
     "login": {
       "action": "Login!",

--- a/client/src/__tests__/Configure.test.tsx
+++ b/client/src/__tests__/Configure.test.tsx
@@ -1,0 +1,85 @@
+import { MockedProvider } from "@apollo/client/testing";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { createMemoryHistory } from "history";
+import { Suspense } from "react";
+import { Router } from "react-router-dom";
+import { AuthProvider } from "../components/AuthProvider";
+import { mockBlankSlate } from "../graphql/__mocks__/auth";
+import { FIRST_TIME_CONFIGURE } from "../graphql/__mutations__/FirstTimeConfigure.gql";
+import { Configure } from "../pages/Configure";
+import { tick } from "./utils";
+
+it("allows user to configure app on the first time", async () => {
+  const { auth } = mockBlankSlate();
+  await auth.init();
+  const history = createMemoryHistory();
+  history.replace("/anywhere/but/home");
+
+  await tick();
+
+  const configure = {
+    request: {
+      query: FIRST_TIME_CONFIGURE,
+      variables: {
+        input: {
+          organization: "my org",
+          firstName: "tina",
+          lastName: "turner",
+          email: "tina@turner.org",
+        },
+      },
+    },
+    result: {
+      data: {
+        configureApp: "00000004-b910-4f6e-8f3c-8201c1111111",
+      },
+    },
+  };
+
+  render(
+    <Suspense fallback={<div />}>
+      <MockedProvider mocks={[configure]}>
+        <Router history={history}>
+          <AuthProvider auth={auth}>
+            <Configure />
+          </AuthProvider>
+        </Router>
+      </MockedProvider>
+    </Suspense>
+  );
+
+  await tick();
+
+  fireEvent.change(screen.getByRole("textbox", { name: /organization/ }), {
+    target: { value: "my org" },
+  });
+
+  fireEvent.change(screen.getByRole("textbox", { name: /firstName/ }), {
+    target: { value: "tina" },
+  });
+
+  fireEvent.change(screen.getByRole("textbox", { name: /lastName/ }), {
+    target: { value: "turner" },
+  });
+
+  fireEvent.change(screen.getByRole("textbox", { name: /email/ }), {
+    target: { value: "tina@turner.org" },
+  });
+
+  await tick();
+
+  fireEvent.click(screen.getByRole("button"));
+
+  // field validation
+  await tick();
+
+  // network request
+  await tick();
+
+  // check for no errors (either from validation or query)
+  expect(document.querySelector('[role="alert"]')).toBeNull();
+  // check that redirect worked
+  expect(history.location.pathname).toEqual(
+    "/admin/users/00000004-b910-4f6e-8f3c-8201c1111111"
+  );
+});

--- a/client/src/__tests__/Router.test.tsx
+++ b/client/src/__tests__/Router.test.tsx
@@ -1,0 +1,37 @@
+import { MockedProvider } from "@apollo/client/testing";
+import { render, screen } from "@testing-library/react";
+import { Suspense } from "react";
+import { MemoryRouter } from "react-router-dom";
+import { AuthProvider } from "../components/AuthProvider";
+import { mockBlankSlate } from "../graphql/__mocks__/auth";
+import { Login } from "../pages/Login/Login";
+import { RenderRoutes } from "../router/Router";
+import { tick } from "./utils";
+
+it("renders the first-time configuration page when app is in blank slate", async () => {
+  const { auth } = mockBlankSlate();
+  await auth.init();
+
+  render(
+    <Suspense fallback={<div />}>
+      <MockedProvider mocks={[]}>
+        <MemoryRouter initialEntries={["/anywhere"]}>
+          <AuthProvider auth={auth}>
+            <RenderRoutes
+              loginComponent={Login}
+              adminRoutes={[]}
+              protectedRoutes={[]}
+              protectedContainer={() => <div />}
+            />
+          </AuthProvider>
+        </MemoryRouter>
+      </MockedProvider>
+    </Suspense>
+  );
+
+  await tick();
+
+  expect(
+    screen.getByRole("textbox", { name: /organization/ })
+  ).toBeInTheDocument();
+});

--- a/client/src/__tests__/auth.test.tsx
+++ b/client/src/__tests__/auth.test.tsx
@@ -1,4 +1,8 @@
-import { mockUserLoggedIn, mockUserLogIn } from "../graphql/__mocks__/auth";
+import {
+  mockBlankSlate,
+  mockUserLoggedIn,
+  mockUserLogIn,
+} from "../graphql/__mocks__/auth";
 
 it("marks user as admin correctly", async () => {
   const { auth } = mockUserLoggedIn({
@@ -38,6 +42,14 @@ it("returns a special error if user has never changed password", async () => {
   expect(await auth.login(user, password)).toEqual("CHANGE_PASSWORD");
   expect(auth.isLoggedIn()).toBe(true);
   expect(auth.getFullName()).toEqual("Penelope Pomegranate");
+});
+
+it("returns a special error if the app is in blank slate mode", async () => {
+  const { auth } = mockBlankSlate();
+  await auth.init();
+
+  expect(auth.initState).toEqual("blank_slate");
+  expect(auth.isBlankSlate()).toBe(true);
 });
 
 it("reports an error if user is not authed", async () => {

--- a/client/src/components/AuthProvider.tsx
+++ b/client/src/components/AuthProvider.tsx
@@ -10,7 +10,7 @@ const AuthContext = React.createContext<Auth | null>(null);
  * Component to hook into suspense and provide the given auth object.
  */
 export const AuthProvider = ({ auth, children }: any) => {
-  if (auth.initState !== "ready") {
+  if (auth.initState !== "ready" && auth.initState !== "blank_slate") {
     throw auth.init();
   }
 

--- a/client/src/graphql/__generated__/FirstTimeConfigure.ts
+++ b/client/src/graphql/__generated__/FirstTimeConfigure.ts
@@ -1,0 +1,18 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { FirstTimeAppConfigurationInput } from "./globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: FirstTimeConfigure
+// ====================================================
+
+export interface FirstTimeConfigure {
+  readonly configureApp: string;
+}
+
+export interface FirstTimeConfigureVariables {
+  readonly input: FirstTimeAppConfigurationInput;
+}

--- a/client/src/graphql/__generated__/globalTypes.ts
+++ b/client/src/graphql/__generated__/globalTypes.ts
@@ -45,6 +45,13 @@ export interface EntryInput {
   readonly count: number;
 }
 
+export interface FirstTimeAppConfigurationInput {
+  readonly organization: string;
+  readonly email: string;
+  readonly firstName: string;
+  readonly lastName: string;
+}
+
 export interface TagInput {
   readonly id?: string | null;
   readonly name?: string | null;

--- a/client/src/graphql/__mocks__/auth.ts
+++ b/client/src/graphql/__mocks__/auth.ts
@@ -153,6 +153,33 @@ export const mockUserLoggedIn = (user?: Partial<UserProfile>) => {
 };
 
 /**
+ * Mock the API in "blank slate" mode.
+ */
+export const mockBlankSlate = () => {
+  const mock = jest.fn(async (uri: string): Promise<Response> => {
+    if (uri === "/api/users/me") {
+      return new Response(
+        JSON.stringify({
+          details: "App is not configured",
+        }),
+        {
+          headers: new Headers({
+            "Content-Type": "application/json",
+          }),
+          status: 418,
+        }
+      );
+    }
+
+    throw new Error("Unexpected request: " + JSON.stringify(uri));
+  }) as typeof fetch;
+
+  const auth = new Auth(mock);
+
+  return { auth, mock } as AuthMockReturnValue;
+};
+
+/**
  * Simulate not being logged in.
  */
 export const mockUserNotLoggedIn = () => {

--- a/client/src/graphql/__mutations__/FirstTimeConfigure.gql.ts
+++ b/client/src/graphql/__mutations__/FirstTimeConfigure.gql.ts
@@ -1,0 +1,7 @@
+import { gql } from "@apollo/client";
+
+export const FIRST_TIME_CONFIGURE = gql`
+  mutation FirstTimeConfigure($input: FirstTimeAppConfigurationInput!) {
+    configureApp(input: $input)
+  }
+`;

--- a/client/src/pages/Configure.tsx
+++ b/client/src/pages/Configure.tsx
@@ -1,29 +1,147 @@
-import { Button, Col, Form, Input, Layout, PageHeader, Row } from "antd";
-import { useTranslation } from "react-i18next";
+import { useMutation } from "@apollo/client";
+import {
+  Alert,
+  Button,
+  Col,
+  Form,
+  Input,
+  Layout,
+  message,
+  PageHeader,
+  Row,
+  Typography,
+} from "antd";
+import { useHistory } from "react-router-dom";
+import { useTranslationWithPrefix } from "../components/useTranslationWithPrefix";
+import {
+  FirstTimeConfigure,
+  FirstTimeConfigureVariables,
+} from "../graphql/__generated__/FirstTimeConfigure";
+import { FIRST_TIME_CONFIGURE } from "../graphql/__mutations__/FirstTimeConfigure.gql";
 
 /**
  * Form for first-time app configuration.
  */
 export const Configure = () => {
-  const { t } = useTranslation();
+  const history = useHistory();
+  const { t, tp } = useTranslationWithPrefix("app.configure");
+  const [configure, { loading, error }] = useMutation<
+    FirstTimeConfigure,
+    FirstTimeConfigureVariables
+  >(FIRST_TIME_CONFIGURE, {
+    onCompleted(data) {
+      message.success(tp("success"));
+      // Redirect to the edit page for the new user. They will be prompted to
+      // login before they can see this.
+      history.replace(`/admin/users/${data.configureApp}`);
+      // Using history.go forces the browser to reload auth state, which ensures
+      // the "blank slate" mode is fully cleaned up on the frontend.
+      history.go(0);
+    },
+    onError() {
+      message.error(tp("error"));
+    },
+  });
 
   return (
     <Layout>
       <Row justify="space-between">
-        <Col span={12} offset={8}>
-          <PageHeader title={t("app.configure")} />
+        <Col span={10} offset={8}>
+          <PageHeader title={tp("title")} />
+          <Typography.Paragraph>{tp("description")}</Typography.Paragraph>
+          {error && (
+            <>
+              <Alert
+                message={tp("error")}
+                description={error.message}
+                showIcon
+                closable
+                type="error"
+              />
+              <br />
+            </>
+          )}
         </Col>
       </Row>
-      <Form labelCol={{ span: 8 }} wrapperCol={{ span: 10 }}>
-        <Form.Item label={t("app.organization")} name="organization">
-          <Input />
+      <Form
+        onFinish={(values) =>
+          configure({
+            variables: {
+              input: values,
+            },
+          })
+        }
+        labelCol={{ span: 8 }}
+        wrapperCol={{ span: 10 }}
+      >
+        <Form.Item
+          rules={[
+            {
+              required: true,
+              message: tp("organizationRequired"),
+            },
+          ]}
+          label={tp("organization")}
+          name="organization"
+        >
+          <Input
+            placeholder={t("placeholder.organization")}
+            aria-required="true"
+            aria-label={tp("organization")}
+          />
         </Form.Item>
-        <Form.Item label={t("app.email")} name="email">
-          <Input />
+        <Form.Item
+          rules={[
+            {
+              required: true,
+              message: tp("firstNameRequired"),
+            },
+          ]}
+          label={tp("firstName")}
+          name="firstName"
+        >
+          <Input
+            placeholder={t("placeholder.firstName")}
+            aria-required="true"
+            aria-label={tp("firstName")}
+          />
+        </Form.Item>
+        <Form.Item
+          rules={[
+            {
+              required: true,
+              message: tp("lastNameRequired"),
+            },
+          ]}
+          label={tp("lastName")}
+          name="lastName"
+        >
+          <Input
+            placeholder={t("placeholder.lastName")}
+            aria-required="true"
+            aria-label={tp("lastName")}
+          />
+        </Form.Item>
+        <Form.Item
+          rules={[
+            { type: "email", message: tp("emailFormat") },
+            {
+              required: true,
+              message: tp("emailRequired"),
+            },
+          ]}
+          label={tp("email")}
+          name="email"
+        >
+          <Input
+            placeholder={t("placeholder.email")}
+            aria-label={tp("email")}
+            aria-required="true"
+          />
         </Form.Item>
         <Form.Item wrapperCol={{ offset: 8 }}>
-          <Button type="primary" htmlType="submit">
-            {t("app.configure")}
+          <Button loading={loading} type="primary" htmlType="submit">
+            {tp("submit")}
           </Button>
         </Form.Item>
       </Form>

--- a/client/src/pages/Configure.tsx
+++ b/client/src/pages/Configure.tsx
@@ -1,0 +1,34 @@
+import { Button, Col, Form, Input, Layout, PageHeader, Row } from "antd";
+import { useTranslation } from "react-i18next";
+
+/**
+ * Form for first-time app configuration.
+ */
+export const Configure = () => {
+  const { t } = useTranslation();
+
+  return (
+    <Layout>
+      <Row justify="space-between">
+        <Col span={12} offset={8}>
+          <PageHeader title={t("app.configure")} />
+        </Col>
+      </Row>
+      <Form labelCol={{ span: 8 }} wrapperCol={{ span: 10 }}>
+        <Form.Item label={t("app.organization")} name="organization">
+          <Input />
+        </Form.Item>
+        <Form.Item label={t("app.email")} name="email">
+          <Input />
+        </Form.Item>
+        <Form.Item wrapperCol={{ offset: 8 }}>
+          <Button type="primary" htmlType="submit">
+            {t("app.configure")}
+          </Button>
+        </Form.Item>
+      </Form>
+    </Layout>
+  );
+};
+
+export default Configure;

--- a/client/src/router/Router.tsx
+++ b/client/src/router/Router.tsx
@@ -89,6 +89,18 @@ export function RenderRoutes({
   const auth = useAuth();
   const Container = protectedContainer;
 
+  // First time login requires the user to configure the app.
+  if (auth.isBlankSlate()) {
+    return (
+      <Switch>
+        <Route
+          path="/"
+          component={React.lazy(() => import("../pages/Configure"))}
+        />
+      </Switch>
+    );
+  }
+
   // Routes that a normal authed user can visit.
   // If the user is not logged in, they will be redirected to the login screen.
   const WrappedPrivate = (props: AnyRouteProps) =>


### PR DESCRIPTION
Currently the app can't be used without running our `python database.py --dummy-data` init script. This PR fixes that by adding a simple bootstrapping UI.

It works like this:
1) When the client makes a request to the API, the API determines if it's in the "blank slate" condition by checking if there's anything in the database (currently just looks at the `organization` table -- if that's empty, nothing has been setup). [Also, if the database does not exist at this point it will now be created automatically, with the correct tables. Things like default roles and categories will also be created here.]
2) If the app is a blank slate, the API will throw a `418` error. The client handles this by displaying the bootstrapping form.
3) The user can enter the organization name, their name, and their email address and press submit.
4) The API creates the Organization and an admin User with the given info, and emails a temporary password to the user
5) User can now log in. The app is no longer in the blank slate mode so permissions are now buttoned up as usual.

<img width="968" alt="image" src="https://user-images.githubusercontent.com/1069899/126553855-a38a62eb-b398-4e92-8e6f-e3ac833c1df3.png">
