### PR TITLE
Cache-bust translations files

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -37,7 +37,7 @@
     "start": "react-scripts start",
     "start-env": "sh -ac '. .env.${REACT_APP_ENV}; react-scripts start'",
     "start:mock": "REACT_APP_ENV=mock yarn run start-env",
-    "build": "react-scripts build",
+    "build": "REACT_APP_BUILD_TS=`date +%s` react-scripts build",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "npx jest --coverage",

--- a/client/src/services/i18next.ts
+++ b/client/src/services/i18next.ts
@@ -21,6 +21,12 @@ i18next
       escapeValue: false, // not needed for react as it escapes by default
     },
     debug: process.env.NODE_ENV === "development",
+    backend: {
+      requestOptions: {
+        cache: "no-cache",
+      },
+      queryStringParams: { t: process.env.REACT_APP_BUILD_TS },
+    },
   });
 
 export default i18next;

--- a/client/src/services/i18next.ts
+++ b/client/src/services/i18next.ts
@@ -25,7 +25,7 @@ i18next
       requestOptions: {
         cache: "no-cache",
       },
-      queryStringParams: { t: process.env.REACT_APP_BUILD_TS },
+      queryStringParams: { t: process.env.REACT_APP_BUILD_TS || "" },
     },
   });
 


### PR DESCRIPTION
Make sure translations files are loaded fresh when we deploy new versions of the app. The cache-busting URL is set by the timestamp of the build.