### PR TITLE
Fix error on user update from admin panel

### DIFF
--- a/client/src/__tests__/AdminEditUser.test.tsx
+++ b/client/src/__tests__/AdminEditUser.test.tsx
@@ -183,7 +183,8 @@ it("allows admin to modify user", async () => {
     {
       first_name: "Cat",
       last_name: "Berry",
-      email: "tester@notrealemail.info",
+      // TODO: Uncomment when Ariadne version is updated. See: https://github.com/stanford-policylab/bbc-50-50/pull/116
+      // email: "tester@notrealemail.info",
       roles: ["be5f8cac-ac65-4f75-8052-8d1b5d40dffe"],
       teams: ["472d17da-ff8b-4743-823f-3f01ea21a349"],
     }

--- a/client/src/pages/Admin/EditUser.tsx
+++ b/client/src/pages/Admin/EditUser.tsx
@@ -305,6 +305,20 @@ export const EditUser = () => {
         wrapperCol={{ span: 14 }}
         initialValues={initialFormState}
         onFinish={async (values) => {
+          // TODO: Remove this hack when Ariadne updates starlette dependency for fastapi-users v8 to work
+          if (initialFormState.email === values.email) {
+            const temp_values = { ...values };
+            // Remove email field if it has not changed so the PATCH endpoint doesn't throw a dupe email error
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            const { email, ...rest } = temp_values;
+            // Save new object without dupe email for user id
+            if (await saveUser(rest)) {
+              setDirty(false);
+            }
+
+            return;
+          }
+
           if (await saveUser(values)) {
             setDirty(false);
           }

--- a/client/src/services/account.ts
+++ b/client/src/services/account.ts
@@ -96,7 +96,8 @@ const checkError = async (
     case httpStatus.FORBIDDEN:
       throw new Error("FORBIDDEN");
     default:
-      throw new Error("UNKNOWN_ERROR");
+      json = await response.json();
+      throw new Error(json.detail || "UNKNOWN_ERROR");
   }
 };
 


### PR DESCRIPTION
The error in [this comment](https://github.com/stanford-policylab/bbc-50-50/pull/116#discussion_r740392262) is caused by a bug in the current version of fastapi-users we are using. It is [fixed](https://github.com/fastapi-users/fastapi-users/issues/733) in version 8.0.0 but that version uses a newer version of the starlette package which is incompatible with the latest release of ariadne.

Ariadne's next milestone [release](https://github.com/mirumee/ariadne/milestone/13) should have starlette updated and in the meantime, this is a hack to work around the inability to update fastapi-users.

I also tried something more complicated in the API in the last couple of days by creating a new patch users route in the users router in an attempt to override the fastapi-users one and modifying the request in middleware (which is frowned upon). 

This small hack much quicker to undo and doesn't interfere with other functions.